### PR TITLE
Validate panic changes

### DIFF
--- a/funds/order_validate.go
+++ b/funds/order_validate.go
@@ -108,7 +108,7 @@ func (funds *orderValidator) ValidateOrder(order *types.Order) (bool, error) {
 	)
 	result := true
 	if chanResult := <-makerChan; !chanResult.success {
-		log.Printf("Insufficient fee token allowance")
+		log.Printf("Insufficient maker token funds")
 		if chanResult.err != nil {
 			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
@@ -118,7 +118,7 @@ func (funds *orderValidator) ValidateOrder(order *types.Order) (bool, error) {
 		result = false
 	}
 	if chanResult := <-feeChan; !chanResult.success {
-		log.Printf("Insufficient fee token allowance")
+		log.Printf("Insufficient fee token funds")
 		if chanResult.err != nil {
 			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
@@ -128,7 +128,7 @@ func (funds *orderValidator) ValidateOrder(order *types.Order) (bool, error) {
 		result = false
 	}
 	if chanResult := <-makerAllowanceChan; !chanResult.success {
-		log.Printf("Insufficient fee token allowance")
+		log.Printf("Insufficient makers token allowance")
 		if chanResult.err != nil {
 			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err

--- a/funds/order_validate.go
+++ b/funds/order_validate.go
@@ -6,8 +6,6 @@ import (
 	"github.com/notegio/openrelay/types"
 	"log"
 	"math/big"
-	"encoding/json"
-	"net/url"
 	"fmt"
 )
 
@@ -109,51 +107,43 @@ func (funds *orderValidator) ValidateOrder(order *types.Order) (bool, error) {
 		feeAllowanceChan,
 	)
 	result := true
-	if chanResult := <-makerChan; !chanResult.success{
-		log.Printf("Insufficient maker token funds")
+	if chanResult := <-makerChan; !chanResult.success {
+		log.Printf("Insufficient fee token allowance")
 		if chanResult.err != nil {
-			switch v := chanResult.err.(type) {
-			case *json.SyntaxError, *url.Error:
-				panic(fmt.Sprintf("RPC Communication Failed: '%v'", v))
-			default:
+			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
 			}
+			panic(fmt.Sprintf("RPC Communication Failed: '%v'", chanResult.err.Error()))
 		}
 		result = false
 	}
 	if chanResult := <-feeChan; !chanResult.success {
-		log.Printf("Insufficient fee token funds")
+		log.Printf("Insufficient fee token allowance")
 		if chanResult.err != nil {
-			switch v := chanResult.err.(type) {
-			case *json.SyntaxError, *url.Error:
-				panic(fmt.Sprintf("RPC Communication Failed: '%v'", v))
-			default:
+			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
 			}
+			panic(fmt.Sprintf("RPC Communication Failed: '%v'", chanResult.err.Error()))
 		}
 		result = false
 	}
 	if chanResult := <-makerAllowanceChan; !chanResult.success {
-		log.Printf("Insufficient maker token allowance")
+		log.Printf("Insufficient fee token allowance")
 		if chanResult.err != nil {
-			switch v := chanResult.err.(type) {
-			case *json.SyntaxError, *url.Error:
-				panic(fmt.Sprintf("RPC Communication Failed: '%v'", v))
-			default:
+			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
 			}
+			panic(fmt.Sprintf("RPC Communication Failed: '%v'", chanResult.err.Error()))
 		}
 		result = false
 	}
 	if chanResult := <-feeAllowanceChan; !chanResult.success {
 		log.Printf("Insufficient fee token allowance")
 		if chanResult.err != nil {
-			switch v := chanResult.err.(type) {
-			case *json.SyntaxError, *url.Error:
-				panic(fmt.Sprintf("RPC Communication Failed: '%v'", v))
-			default:
+			if chanResult.err.Error() == "no contract code at given address" {
 				return false, chanResult.err
 			}
+			panic(fmt.Sprintf("RPC Communication Failed: '%v'", chanResult.err.Error()))
 		}
 		result = false
 	}

--- a/funds/order_validate_test.go
+++ b/funds/order_validate_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
+	"errors"
 )
 
 func createMockBalanceChecker(tokenAddress, userAddress string, tokenAmount string, feeTokenAmount string, t *testing.T) funds.BalanceChecker {
@@ -96,6 +97,25 @@ func TestErrorPanic(t *testing.T) {
 			t.Errorf("Expected panic from JSON error");
 		}
 	}()
+	feeTokenAddress, _ := common.HexToBytes("e41d2489571d322189246dafa5ebde1f4699f498")
+	tokenProxyAddress, _ := common.HexToBytes("d4fd252d7d2c9479a8d616f510eac6243b5dddf9")
+	validator := funds.NewOrderValidator(balanceChecker, config.StaticFeeToken(feeTokenAddress), config.StaticTokenProxy(tokenProxyAddress))
+
+	testOrderBytes, _ := hex.DecodeString("90fe2af704b34e0224bf2299c838e04d4dcf1364324454186bb728a3ea55750e0618ff1b18ce6cf800000000000000000000000000000000000000001dad4783cf3fe3085c1426157ab175a6119a04ba05d090b51c40b020eab3bfcb6a2dff130df22e9c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b5e3af16b18800000000000000000000000000000000000000000000000000000de0b6b3a7640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000059938ac4000643508ff7019bfb134363a86e98746f6c33262e68daf992b8df064217222b1b021fe6dba378a347ea5c581adcd0e0e454e9245703d197075f5d037d0935ac2e12ac107cb04be663f542394832bbcb348deda8b5aa393a97a4cc3139501007f1")
+	var testOrderByteArray [441]byte
+	copy(testOrderByteArray[:], testOrderBytes[:])
+	newOrder := types.OrderFromBytes(testOrderByteArray)
+	filledInt := new(big.Int)
+	// Half the taker token amount for the order
+	filledInt.SetString("500000000000000000", 10)
+	copy(newOrder.TakerTokenAmountFilled[:], gethCommon.LeftPadBytes(filledInt.Bytes(), 32))
+
+	validator.ValidateOrder(newOrder)
+}
+
+func TestErrorNoContract(t *testing.T) {
+	err := errors.New("no contract code at given address")
+	balanceChecker := funds.NewErrorMockBalanceChecker(err)
 	feeTokenAddress, _ := common.HexToBytes("e41d2489571d322189246dafa5ebde1f4699f498")
 	tokenProxyAddress, _ := common.HexToBytes("d4fd252d7d2c9479a8d616f510eac6243b5dddf9")
 	validator := funds.NewOrderValidator(balanceChecker, config.StaticFeeToken(feeTokenAddress), config.StaticTokenProxy(tokenProxyAddress))


### PR DESCRIPTION
If an order references a token that doesn't exist, it's an invalid
order. Any other errors we get while validating an order are
indicators of problems communicating with the RPC server, rather than
problems with the order, and so should panic.