### PR TITLE
Filter subprovider

### DIFF
--- a/docker-compose-aws-stack.yml
+++ b/docker-compose-aws-stack.yml
@@ -1,94 +1,5 @@
 version: "3"
 services:
-  monitor-ethnode:
-    build:
-      context: ./
-      dockerfile: Dockerfile.ethnode
-    image: 201322628656.dkr.ecr.us-east-2.amazonaws.com/openrelay-ethnode
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: monitor-ethnode
-        # awslogs-create-group: "true"
-    ports:
-      - "8545"
-      - "30303/tcp"
-      - "30303/udp"
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - engine.labels.enginetype == Ethereum
-  state-ethnode:
-    build:
-      context: ./
-      dockerfile: Dockerfile.ethnode
-    image: 201322628656.dkr.ecr.us-east-2.amazonaws.com/openrelay-ethnode
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: state-ethnode
-        # awslogs-create-group: "true"
-    ports:
-      - "8545"
-      - "30303/tcp"
-      - "30303/udp"
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - engine.labels.enginetype == Ethereum
-    command: "--syncmode=light --rpc --rpcaddr 0.0.0.0"
-  standby-ethnode:
-    build:
-      context: ./
-      dockerfile: Dockerfile.ethnode
-    image: 201322628656.dkr.ecr.us-east-2.amazonaws.com/openrelay-ethnode
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: standby-ethnode
-        # awslogs-create-group: "true"
-    ports:
-      - "8545"
-      - "30303/tcp"
-      - "30303/udp"
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - engine.labels.enginetype == Ethereum
-    command: "--syncmode=light --rpc --rpcaddr 0.0.0.0"
-  monitor-haproxy:
-    build:
-      context: ./
-      dockerfile: Dockerfile.monproxy
-    image: 201322628656.dkr.ecr.us-east-2.amazonaws.com/openrelay-monproxy
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: monproxy
-        # awslogs-create-group: "true"
-    deploy:
-      mode: global
-      placement:
-        constraints:
-          - engine.labels.enginetype == Ethereum
-  state-haproxy:
-    build:
-      context: ./
-      dockerfile: Dockerfile.stateproxy
-    image: 201322628656.dkr.ecr.us-east-2.amazonaws.com/openrelay-stateproxy
-    logging:
-      driver: awslogs
-      options:
-        awslogs-group: stateproxy
-        # awslogs-create-group: "true"
-    deploy:
-      mode: global
-      placement:
-        constraints:
-          - engine.labels.enginetype == Ethereum
   ingest:
     build:
       context: ./
@@ -119,7 +30,7 @@ services:
       options:
         awslogs-group: fillupdate
         # awslogs-create-group: "true"
-    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://ingest", "queue://fundcheck"]
+    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://ingest", "queue://fundcheck"]
     deploy:
       mode: global
       # endpoint_mode: dnsrr
@@ -137,7 +48,7 @@ services:
       options:
         awslogs-group: fundcheckrelay
         # awslogs-create-group: "true"
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://fundcheck", "queue://delay1", "topic://instant-broadcast"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://fundcheck", "queue://delay1", "topic://instant-broadcast"]
     deploy:
       mode: global
       placement:
@@ -186,6 +97,9 @@ services:
         awslogs-group: blockmonitor
         # awslogs-create-group: "true"
     command: ["./node_modules/.bin/truffle", "exec", "blockMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "topic://newblocks", "--network", "main"]
+    environment:
+      ETHEREUM_URL: "${ETHEREUM_URL:-http://ethnode:8545}"
+      USE_FILTER_PROVIDER: "1"
     deploy:
       replicas: 1
       placement:
@@ -202,6 +116,9 @@ services:
         awslogs-group: fillmonitor
         # awslogs-create-group: "true"
     command: ["./node_modules/.bin/truffle", "exec", "exchangeMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "queue://ordersfilled", "0xC22d5b2951DB72B44CFb8089bb8CD374A3c354eA", "--network", "main"]
+    environment:
+      ETHEREUM_URL: "${ETHEREUM_URL:-http://ethnode:8545}"
+      USE_FILTER_PROVIDER: "1"
     deploy:
       replicas: 1
       placement:
@@ -251,7 +168,7 @@ services:
       options:
         awslogs-group: fillupdate2
         # awslogs-create-group: "true"
-    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://recheck", "queue://recheck2"]
+    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://recheck", "queue://recheck2"]
     deploy:
       mode: global
       placement:
@@ -267,7 +184,7 @@ services:
       options:
         awslogs-group: fundcheckrelay2
         # awslogs-create-group: "true"
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://recheck2", "queue://indexer"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://recheck2", "queue://indexer"]
     deploy:
       mode: global
       placement:
@@ -359,7 +276,7 @@ services:
       options:
         awslogs-group: fillupdate-continuous
         # awslogs-create-group: "true"
-    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://continuous_recheck", "queue://fund_continuous_recheck", "queue://indexer"]
+    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://continuous_recheck", "queue://fund_continuous_recheck", "queue://indexer"]
     deploy:
       mode: global
       placement:
@@ -377,7 +294,7 @@ services:
       options:
         awslogs-group: fundcheckrelay-continuous
         # awslogs-create-group: "true"
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://state-haproxy:8545}", "queue://fund_continuous_recheck", "queue://unindexer", "--invert"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_URL:-http://state-haproxy:8545}", "queue://fund_continuous_recheck", "queue://unindexer", "--invert"]
     deploy:
       mode: global
       placement:

--- a/docker-compose-testrpc.yml
+++ b/docker-compose-testrpc.yml
@@ -83,10 +83,14 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.blockmonitor
-    command: ["./node_modules/.bin/truffle", "exec", "blockMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "topic://newblocks", "--network", "testnet"]
+    command: ["./node_modules/.bin/truffle", "exec", "blockMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "topic://newblocks", "--network", "main"]
+    environment:
+      ETHEREUM_URL: "http://ethnode:8545"
+      USE_FILTER_PROVIDER: "1"
     depends_on:
       - redis
       - ethnode
+    restart: on-failure
     deploy:
       replicas: 1
       restart_policy:
@@ -95,7 +99,10 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.fillmonitor
-    command: ["./node_modules/.bin/truffle", "exec", "exchangeMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "queue://ordersfilled", "0xC22d5b2951DB72B44CFb8089bb8CD374A3c354eA", "--network", "testnet"]
+    command: ["./node_modules/.bin/truffle", "exec", "exchangeMonitor.js", "redis://${REDIS_HOST:-redis:6379}", "queue://ordersfilled", "0xC22d5b2951DB72B44CFb8089bb8CD374A3c354eA", "--network", "main"]
+    environment:
+      ETHEREUM_URL: "http://ethnode:8545"
+      USE_FILTER_PROVIDER: "1"
     depends_on:
       - ethnode
   fillindexer:
@@ -152,6 +159,8 @@ services:
       context: ./
       dockerfile: Dockerfile.testinit
     command: ["/project/setup.sh", "redis://${REDIS_HOST:-redis:6379}"]
+    environment:
+      ETHEREUM_URL: "http://ethnode:8545"
     depends_on:
       - redis
   entrypoint:

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -25,6 +25,11 @@
         }
       }
     },
+    "abstract-leveldown": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA=="
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -74,6 +79,16 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "async-eventemitter": {
+      "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -437,6 +452,11 @@
         }
       }
     },
+    "checkpoint-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY="
+    },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
@@ -456,6 +476,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "co": {
       "version": "4.6.0",
@@ -554,10 +579,37 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA=="
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -578,6 +630,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
@@ -627,15 +684,42 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+    },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
     },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "dependencies": {
+        "prr": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+        }
+      }
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q=="
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0="
     },
     "es6-promise": {
       "version": "4.1.1",
@@ -657,6 +741,38 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
+    "eth-block-tracker": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.2.2.tgz",
+      "integrity": "sha512-H1DdocgLD2er/88oJUGlC780yrcWf2JIcYFDN/4J5LuN9nu9EgO0QYqTNTCyCKqtOuIFLDZRgnxzAYD+Wg7d9A=="
+    },
+    "eth-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4="
+    },
+    "eth-sig-util": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.0.tgz",
+      "integrity": "sha1-rUL9HZxg//Gb3vc3e0L7OOku5+E=",
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee6ded67235a98f3ef4ae2a338aee70a9f68fe20",
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+            }
+          }
+        }
+      }
+    },
+    "ethereum-common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+    },
     "ethereumjs-abi": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.4.tgz",
@@ -669,10 +785,63 @@
         }
       }
     },
+    "ethereumjs-account": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
+      "integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+        }
+      }
+    },
+    "ethereumjs-block": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
+      "integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+        }
+      }
+    },
+    "ethereumjs-tx": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
+      "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        }
+      }
+    },
     "ethereumjs-util": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
       "integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8="
+    },
+    "ethereumjs-vm": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
+      "integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+        },
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+        }
+      }
     },
     "ethjs-util": {
       "version": "0.1.4",
@@ -699,6 +868,16 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fake-merkle-patricia-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM="
+    },
+    "fetch-ponyfill": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM="
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -713,6 +892,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
       "integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw="
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -733,6 +922,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gauge": {
       "version": "2.7.4",
@@ -803,6 +1002,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8="
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -832,6 +1036,11 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -893,6 +1102,16 @@
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
       "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU="
     },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -950,20 +1169,55 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+    },
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1010,6 +1264,16 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-rpc-error": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+      "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI="
+    },
+    "json-rpc-random-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1083,6 +1347,70 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
+    "level-codec": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig=="
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "level-ws": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+        }
+      }
+    },
+    "levelup": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ=="
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -1153,6 +1481,11 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
     },
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -1167,6 +1500,18 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg="
+        }
+      }
+    },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w=="
         }
       }
     },
@@ -1187,6 +1532,23 @@
         }
       }
     },
+    "merkle-patricia-tree": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.2.0.tgz",
+      "integrity": "sha1-ekeHsSYqsA/psgSrRxsAUzIwbvo=",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+        }
+      }
+    },
     "mime": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
@@ -1201,6 +1563,11 @@
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU="
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -1252,6 +1619,11 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
       "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="
+    },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -1281,6 +1653,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
     },
     "object-keys": {
       "version": "0.4.0",
@@ -1312,6 +1689,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1326,6 +1708,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-type": {
       "version": "1.1.0",
@@ -1379,6 +1766,11 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -1415,6 +1807,16 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
         }
       }
+    },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "publish-release": {
       "version": "1.3.3",
@@ -1577,6 +1979,16 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q=="
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k="
+    },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
@@ -1591,6 +2003,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
+    },
+    "rustbn.js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
+      "integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
     },
     "rx": {
       "version": "2.5.3",
@@ -1607,6 +2024,11 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
       "integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ=="
     },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -1621,6 +2043,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "sha.js": {
       "version": "2.4.8",
@@ -1719,6 +2146,11 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo="
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -1753,6 +2185,23 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU="
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "tar-fs": {
       "version": "1.15.3",
@@ -1800,6 +2249,11 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -1869,6 +2323,18 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.0.tgz",
       "integrity": "sha1-qru+Nf5sq+gRZZCHpVzIbpkzbHQ="
     },
+    "web3-provider-engine": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.3.3.tgz",
+      "integrity": "sha1-H2307FQBYRJfPl9QG7Dlavg6Ad8=",
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+        }
+      }
+    },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -1893,6 +2359,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xhr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
+      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM="
     },
     "xhr2": {
       "version": "0.1.4",

--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,8 @@
     "bignumber.js": "^4.1.0",
     "redis": "^2.8.0",
     "truffle": "^3.4.9",
-    "web3": "^0.20.0"
+    "web3": "^0.20.0",
+    "web3-provider-engine": "^13.3.3"
   },
   "devDependencies": {
     "uuid": "^3.1.0"

--- a/js/sendOrder.js
+++ b/js/sendOrder.js
@@ -18,59 +18,62 @@ function getAsync(redisClient, key) {
 var requiredFee = new web3.BigNumber("500000000000000000");
 
 module.exports = function(done){
-    var redisClient = redis.createClient(process.argv[4]);
-    var zeroEx = new ZeroEx.ZeroEx(web3.currentProvider);
-    var order = {
-        expirationUnixTimestampSec: new web3.BigNumber(Math.floor(Date.now()/1000) + (60*60*24)),
-        feeRecipient: "0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea",
-        maker: web3.eth.accounts[0],
-        makerFee: requiredFee.div(2),
-        makerTokenAmount: new web3.BigNumber(10000),
-        salt: ZeroEx.ZeroEx.generatePseudoRandomSalt(),
-        taker: "0x0000000000000000000000000000000000000000",
-        takerFee: requiredFee.minus(requiredFee.div(2)), // account for rounding
-        takerTokenAmount: new web3.BigNumber(10000),
-    };
-    zeroEx.proxy.getContractAddressAsync().then((proxyAddress) => {
-        return Promise.all([
-            getAsync(redisClient, "feeToken::address").then((feeAddress) => {
-                Token.at("0x" + feeAddress).approve(proxyAddress, requiredFee.div(2));
-            }),
-            getAsync(redisClient, "tokenX::address").then((address) => {
-                order["makerTokenAddress"] = "0x" + address;
-                Token.at("0x" + address).approve(proxyAddress, new web3.BigNumber(10000));
-            }),
-            getAsync(redisClient, "tokenY::address").then((address) => {
-                order["takerTokenAddress"] = "0x" + address;
-            }),
-            zeroEx.exchange.getContractAddressAsync().then((address) => {
-                order["exchangeContractAddress"] = address;
-            })
-        ])
-    }).then(() => {
-        var orderHash = ZeroEx.ZeroEx.getOrderHashHex(order);
-        return zeroEx.signOrderHashAsync(orderHash, web3.eth.accounts[0]);
-    }).then((signature) => {
-        order["ecSignature"] = signature;
-        var start = Date.now();
-        var req = http.request({
-            host: "ingest",
-            port: "8080",
-            path: "/v0.0/order",
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            }
-        }, (res) => {
-            console.log(res.statusCode);
-            res.on('data', console.log);
-            res.on('end', () => {
-                console.log(Date.now() - start);
-                redisClient.quit();
-                done();
+    web3.eth.getAccounts((err, accounts) => {
+        var defaultAccount = accounts[0];
+        var redisClient = redis.createClient(process.argv[4]);
+        var zeroEx = new ZeroEx.ZeroEx(web3.currentProvider);
+        var order = {
+            expirationUnixTimestampSec: new web3.BigNumber(Math.floor(Date.now()/1000) + (60*60*24)),
+            feeRecipient: "0xc22d5b2951db72b44cfb8089bb8cd374a3c354ea",
+            maker: defaultAccount,
+            makerFee: requiredFee.div(2),
+            makerTokenAmount: new web3.BigNumber(10000),
+            salt: ZeroEx.ZeroEx.generatePseudoRandomSalt(),
+            taker: "0x0000000000000000000000000000000000000000",
+            takerFee: requiredFee.minus(requiredFee.div(2)), // account for rounding
+            takerTokenAmount: new web3.BigNumber(10000),
+        };
+        zeroEx.proxy.getContractAddressAsync().then((proxyAddress) => {
+            return Promise.all([
+                getAsync(redisClient, "feeToken::address").then((feeAddress) => {
+                    Token.at("0x" + feeAddress).approve(proxyAddress, requiredFee.div(2));
+                }),
+                getAsync(redisClient, "tokenX::address").then((address) => {
+                    order["makerTokenAddress"] = "0x" + address;
+                    Token.at("0x" + address).approve(proxyAddress, new web3.BigNumber(10000));
+                }),
+                getAsync(redisClient, "tokenY::address").then((address) => {
+                    order["takerTokenAddress"] = "0x" + address;
+                }),
+                zeroEx.exchange.getContractAddressAsync().then((address) => {
+                    order["exchangeContractAddress"] = address;
+                })
+            ])
+        }).then(() => {
+            var orderHash = ZeroEx.ZeroEx.getOrderHashHex(order);
+            return zeroEx.signOrderHashAsync(orderHash, defaultAccount);
+        }).then((signature) => {
+            order["ecSignature"] = signature;
+            var start = Date.now();
+            var req = http.request({
+                host: "ingest",
+                port: "8080",
+                path: "/v0.0/order",
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            }, (res) => {
+                console.log(res.statusCode);
+                res.on('data', console.log);
+                res.on('end', () => {
+                    console.log(Date.now() - start);
+                    redisClient.quit();
+                    done();
+                });
             });
+            req.write(JSON.stringify(order));
+            req.end();
         });
-        req.write(JSON.stringify(order));
-        req.end();
     });
 }

--- a/js/setup.sh
+++ b/js/setup.sh
@@ -4,5 +4,5 @@ cd $(dirname $0)
 
 REDIS_URL=${1:-redis://redis:6379}
 
-./node_modules/.bin/truffle migrate --network testnet
-./node_modules/.bin/truffle exec netinit.js $REDIS_URL --network testnet
+ETHEREUM_URL="$ETHEREUM_URL" ./node_modules/.bin/truffle migrate --network main
+ETHEREUM_URL="$ETHEREUM_URL" ./node_modules/.bin/truffle exec netinit.js $REDIS_URL --network main

--- a/js/test/monitor.js
+++ b/js/test/monitor.js
@@ -13,7 +13,12 @@ function MockRedisClient() {
 }
 
 function MockWeb3(blockNumber) {
-    this.eth = {blockNumber: blockNumber || 0}
+    this.eth = {
+        blockNumber: blockNumber || 0,
+        getBlockNumber(cb) {
+            cb(null, this.blockNumber);
+        }
+    }
     this.addBlock = () => {
         this.eth.blockNumber++;
     }

--- a/js/truffle.js
+++ b/js/truffle.js
@@ -1,5 +1,26 @@
+var ProviderEngine = require("web3-provider-engine");
+var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
+var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
+var Web3 = require("web3");
+const FilterSubprovider = require('web3-provider-engine/subproviders/filters.js');
+
+function getEngine() {
+    if(!process.env.USE_FILTER_PROVIDER) {
+        return new Web3.providers.HttpProvider(process.env.ETHEREUM_URL)
+    }
+    var engine = new ProviderEngine();
+    engine.addProvider(new FilterSubprovider());
+    engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(process.env.ETHEREUM_URL)));
+    engine.start();
+    return engine
+}
+
 module.exports = {
   networks: {
+    main: {
+      provider: getEngine,
+      network_id: "*"
+    },
     development: {
       host: "localhost",
       port: 8546,
@@ -14,11 +35,6 @@ module.exports = {
       host: "172.17.0.4",
       port: 8545,
       network_id: "*" // Match any network id
-    },
-    main: {
-      host: "monitor-haproxy",
-      port: 8545,
-      network_id: "*"
     }
   }
 };


### PR DESCRIPTION
The providerEngine system offers a filterProvider which filters
blocks locally instead of installing filters on the RPC nodes. If
we use this for our monitors, we can simply load balance across a
pool of eth nodes instead of having to ensure that the monitoring
servers are always communicating with the same instance.

I still want to get the monitoring nodes using the websocket
subscriptions soon, but in the short term this should simplify a
lot of things.