### PR TITLE
Feature/breakout circle 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - checkout
       - run: npm install
       - run: make mock
+      - run: make nodesetup
       - run: make jstest
 
   golang_build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: bin
+      - run: make mock
       - run: make gotest
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - image: cnadiminti/dynamodb-local
     steps:
       - checkout
+      - run: sudo apt install python3-virtualenv
       - run: make mock
       - run: make pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - image: cnadiminti/dynamodb-local
     steps:
       - checkout
-      - run: sudo apt install python3-virtualenv
+      - run: sudo apt install python3-virtualenv python3.6-dev libev-dev
       - run: sudo ln -s  /usr/lib/python3/dist-packages/virtualenv.py /usr/local/bin/virtualenv
       - run: sudo  chmod +x /usr/lib/python3/dist-packages/virtualenv.py
       - run: make mock
@@ -30,6 +30,16 @@ jobs:
       - run: make mock
       - run: make nodesetup
       - run: make jstest
+  golang_build_delayrelay:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/delayrelay
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - delayrelay
 
   golang_build_and_test:
     docker:
@@ -49,6 +59,24 @@ jobs:
       - run: make mock
       - run: make bin
       - run: make gotest
+  test_delayrelay:
+    docker:
+      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+      - image: circleci/golang:1.8
+        environment:
+          AWS_ACCESS_KEY_ID: placeholder
+          AWS_SECRET_ACCESS_KEY: placeholder
+          AWS_DEFAULT_REGION: us-east-1
+      - image: postgres
+        environment:
+          POSTGRES_PASSWORD: secret
+      - image: redis
+      - image: cnadiminti/dynamodb-local
+    steps:
+      - checkout
+      - attach_workspace:
+          at: bin
+      - run: ls -lah bin
 workflows:
   version: 2
   build_and_test:
@@ -56,3 +84,7 @@ workflows:
       - python_build_and_test
       - node_build_and_test
       - golang_build_and_test
+      - golang_build_delayrelay
+      - test_delayrelay:
+          requires:
+            golang_build_delayrelay

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - checkout
       - run: npm install
       - run: make mock
-      - run: make jtest
+      - run: make jstest
 
   golang_build_and_test:
     docker:
@@ -43,6 +43,7 @@ jobs:
     steps:
       - checkout
       - run: make mock
+      - run: make bin
       - run: make gotest
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           AWS_ACCESS_KEY_ID: placeholder
           AWS_SECRET_ACCESS_KEY: placeholder
           AWS_DEFAULT_REGION: us-east-1
-      - image: cnadiminti/dynamodb-local
+      - image: redis
     steps:
       - checkout
       - run: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
           root: bin
           paths:
             - searchapi
-  test_delayrelay:
+  golang_test:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,4 +87,4 @@ workflows:
       - golang_build_delayrelay
       - test_delayrelay:
           requires:
-            golang_build_delayrelay
+            - golang_build_delayrelay

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   python_build_and_test:
     docker:
-      - image: circleci/python:1.8
+      - image: circleci/python:3.6
         environment:
           AWS_ACCESS_KEY_ID: placeholder
           AWS_SECRET_ACCESS_KEY: placeholder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - checkout
       - run: sudo apt install python3-virtualenv
+      - run: sudo ln -s  /usr/lib/python3/dist-packages/virtualenv.py /usr/local/bin/virtualenv
+      - run: sudo  chmod +x /usr/lib/python3/dist-packages/virtualenv.py
       - run: make mock
       - run: make pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
       - image: cnadiminti/dynamodb-local
     steps:
       - checkout
-      - run: sudo apt install python3-virtualenv python3.6-dev libev-dev
-      - run: sudo ln -s  /usr/lib/python3/dist-packages/virtualenv.py /usr/local/bin/virtualenv
+      - run: sudo apt install python3-virtualenv python3-dev libev-dev
+      - run: sudo ln -s /usr/lib/python3/dist-packages/virtualenv.py /usr/local/bin/virtualenv
       - run: sudo  chmod +x /usr/lib/python3/dist-packages/virtualenv.py
       - run: make mock
       - run: make pytest
@@ -40,25 +40,126 @@ jobs:
           root: bin
           paths:
             - delayrelay
-
-  golang_build_and_test:
+  golang_build_fundcheckrelay:
     docker:
-      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.8
-        environment:
-          AWS_ACCESS_KEY_ID: placeholder
-          AWS_SECRET_ACCESS_KEY: placeholder
-          AWS_DEFAULT_REGION: us-east-1
-      - image: postgres
-        environment:
-          POSTGRES_PASSWORD: secret
-      - image: redis
-      - image: cnadiminti/dynamodb-local
     steps:
       - checkout
-      - run: make mock
-      - run: make bin
-      - run: make gotest
+      - run: make bin/fundcheckrelay
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - fundcheckrelay
+  golang_build_getbalance:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/getbalance
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - getbalance
+  golang_build_ingest:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/ingest
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - ingest
+  golang_build_initialize:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/initialize
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - initialize
+  golang_build_simplerelay:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/simplerelay
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - simplerelay
+  golang_build_validateorder:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/validateorder
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - validateorder
+  golang_build_fillupdate:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/fillupdate
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - fillupdate
+  golang_build_indexer:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/indexer
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - indexer
+  golang_build_fillindexer:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/fillindexer
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - fillindexer
+  golang_build_exchangesplitter:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/exchangesplitter
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - exchangesplitter
+  golang_build_automigrate:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/automigrate
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - automigrate
+  golang_build_searchapi:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: make bin/searchapi
+      - persist_to_workspace:
+          root: bin
+          paths:
+            - searchapi
   test_delayrelay:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
@@ -76,15 +177,39 @@ jobs:
       - checkout
       - attach_workspace:
           at: bin
-      - run: ls -lah bin
+      - run: make gotest
 workflows:
   version: 2
   build_and_test:
     jobs:
       - python_build_and_test
       - node_build_and_test
-      - golang_build_and_test
       - golang_build_delayrelay
-      - test_delayrelay:
+      - golang_build_fundcheckrelay
+      - golang_build_getbalance
+      - golang_build_ingest
+      - golang_build_initialize
+      - golang_build_simplerelay
+      - golang_build_validateorder
+      - golang_build_fillupdate
+      - golang_build_indexer
+      - golang_build_fillindexer
+      - golang_build_exchangesplitter
+      - golang_build_automigrate
+      - golang_build_searchapi
+      - golang_build_delayrelay
+      - golang_test:
           requires:
             - golang_build_delayrelay
+            - golang_build_fundcheckrelay
+            - golang_build_getbalance
+            - golang_build_ingest
+            - golang_build_initialize
+            - golang_build_simplerelay
+            - golang_build_validateorder
+            - golang_build_fillupdate
+            - golang_build_indexer
+            - golang_build_fillindexer
+            - golang_build_exchangesplitter
+            - golang_build_automigrate
+            - golang_build_searchapi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,33 @@
 version: 2
 jobs:
-  build_and_test:
+  python_build_and_test:
+    docker:
+      - image: circleci/python:1.8
+        environment:
+          AWS_ACCESS_KEY_ID: placeholder
+          AWS_SECRET_ACCESS_KEY: placeholder
+          AWS_DEFAULT_REGION: us-east-1
+      - image: cnadiminti/dynamodb-local
+    steps:
+      - checkout
+      - run: make mock
+      - run: make pytest
+
+  node_build_and_test:
+    docker:
+      - image: circleci/node:8
+        environment:
+          AWS_ACCESS_KEY_ID: placeholder
+          AWS_SECRET_ACCESS_KEY: placeholder
+          AWS_DEFAULT_REGION: us-east-1
+      - image: cnadiminti/dynamodb-local
+    steps:
+      - checkout
+      - run: npm install
+      - run: make mock
+      - run: make jtest
+
+  golang_build_and_test:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.8
@@ -15,21 +42,12 @@ jobs:
       - image: cnadiminti/dynamodb-local
     steps:
       - checkout
-      - run: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
-      - run: sudo apt-get install software-properties-common python-software-properties
-      - run: echo "deb http://ftp.de.debian.org/debian testing main" | sudo tee -a /etc/apt/sources.list
-      - run: sudo apt-get -qq update
-      - run: sudo apt-get install python3.6 python3-virtualenv python3.6-dev libev-dev libdpkg-perl
-      - run: sudo ln -s  /usr/lib/python3/dist-packages/virtualenv.py /usr/local/bin/virtualenv
-      - run: sudo  chmod +x /usr/lib/python3/dist-packages/virtualenv.py
-      - run:
-          name: install npm, alias and execute build
-          command: |
-              . ~/.nvm/nvm.sh && nvm install 8.0.0 && nvm alias default node
-              make all
-              make test_no_docker
+      - run: make mock
+      - run: make gotest
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_and_test
+      - python_build_and_test
+      - node_build_and_test
+      - golang_build_and_test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ PACKAGE  = github.com/notegio/openrelay
 GOPATH   = $(CURDIR)/.gopath
 BASE     = $(GOPATH)/src/$(PACKAGE)
 GOSTATIC = go build -a -installsuffix cgo -ldflags '-extldflags "-static"'
-command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 
 all: bin nodesetup truffleCompile docker-cfg/ca-certificates.crt
 
@@ -102,6 +101,7 @@ gotest: $(BASE)/tmp/redis.containerid $(BASE)/tmp/postgres.containerid
 	cd $(BASE)/db &&  POSTGRES_HOST=localhost POSTGRES_USER=postgres POSTGRES_PASSWORD=secret go test
 
 pytest: $(BASE)/py/.env $(BASE)/tmp/dynamo.containerid
+	command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 	cd $(BASE)/py && DYNAMODB_HOST="http://localhost:8000" $(BASE)/py/.env/bin/python .env/bin/nosetests
 
 jstest: $(BASE)/tmp/redis.containerid

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGE  = github.com/notegio/openrelay
 GOPATH   = $(CURDIR)/.gopath
 BASE     = $(GOPATH)/src/$(PACKAGE)
 GOSTATIC = go build -a -installsuffix cgo -ldflags '-extldflags "-static"'
-
+command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 
 all: bin nodesetup truffleCompile docker-cfg/ca-certificates.crt
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ $(BASE)/tmp/dynamo.containerid:
 	docker run -d -p 8000:8000 cnadiminti/dynamodb-local > $(BASE)/tmp/dynamo.containerid
 
 $(BASE)/py/.env: $(BASE)
-	command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 	virtualenv -p python3.6 $(BASE)/py/.env || virtualenv -p python3.4 $(BASE)/py/.env
 	$(BASE)/py/.env/bin/python $(BASE)/py/.env/bin/pip install -r $(BASE)/py/requirements/api.txt
 	$(BASE)/py/.env/bin/python $(BASE)/py/.env/bin/pip install -r $(BASE)/py/requirements/indexer.txt

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ docker-cfg/ca-certificates.crt:
 
 test: $(BASE)/tmp/dynamo.containerid $(BASE)/tmp/redis.containerid jstest gotest pytest dockerstop
 test_no_docker: mock jstest gotest pytest
-mock:
+mock: $(BASE)
 	mkdir -p $(BASE)/tmp
 	touch $(BASE)/tmp/redis.containerid
 	touch $(BASE)/tmp/postgres.containerid

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ $(BASE)/tmp/dynamo.containerid:
 	docker run -d -p 8000:8000 cnadiminti/dynamodb-local > $(BASE)/tmp/dynamo.containerid
 
 $(BASE)/py/.env: $(BASE)
+	command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 	virtualenv -p python3.6 $(BASE)/py/.env || virtualenv -p python3.4 $(BASE)/py/.env
 	$(BASE)/py/.env/bin/python $(BASE)/py/.env/bin/pip install -r $(BASE)/py/requirements/api.txt
 	$(BASE)/py/.env/bin/python $(BASE)/py/.env/bin/pip install -r $(BASE)/py/requirements/indexer.txt
@@ -101,7 +102,6 @@ gotest: $(BASE)/tmp/redis.containerid $(BASE)/tmp/postgres.containerid
 	cd $(BASE)/db &&  POSTGRES_HOST=localhost POSTGRES_USER=postgres POSTGRES_PASSWORD=secret go test
 
 pytest: $(BASE)/py/.env $(BASE)/tmp/dynamo.containerid
-	command -v virtualenv >/dev/null 2>&1 || alias virtualenv='python -m virtualenv'
 	cd $(BASE)/py && DYNAMODB_HOST="http://localhost:8000" $(BASE)/py/.env/bin/python .env/bin/nosetests
 
 jstest: $(BASE)/tmp/redis.containerid


### PR DESCRIPTION
I've gone and made everything as parallel as I can.

These tests/processes all tie into your makefile. If you change it, it should be easy-ish to maintain going forward.

Total time of execution: 03:29

Seems to be a bit faster.

At commit: https://github.com/NoteGio/openrelay/commit/377d95b64ecd346e22073e02ac7f8f2951abe1f 
You can use it being broken out by the language, instead of this granular that I have in this PR. Let me know what approach is better for you.

Worth reading for the virtualenv management:
https://circleci.com/docs/2.0/language-python/#config-walkthrough

python -m venv might be a better thing to do, but it works in this PR, so ship it.

I had issues with the python headers. I gave up and went with python3-dev, even though that is version 3.4 according to `sudo apt-cache show python3-dev`. 

a docker python base image (that circleci extends off of) is here: https://github.com/docker-library/python/blob/a1aa406bfd8c7b129e6e0ee0ba972b863624ac0d/3.6/alpine3.6/Dockerfile

They're just downloading the version, and unzipping it. no package management. I don't know why the base image does not have python.h file for c compiling of pip packages.