### PR TITLE
28 expired orders

### DIFF
--- a/search/orderbook.go
+++ b/search/orderbook.go
@@ -33,11 +33,12 @@ func OrderBookHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 			returnError(w, err, 400)
 			return
 		}
+		currentTime := getExpTime(queryObject)
 		baseTokenAddress := common.BytesToOrAddress(baseTokenAddressBytes)
 		quoteTokenAddress := common.BytesToOrAddress(quoteTokenAddressBytes)
 		orderBook := &OrderBook{[]dbModule.Order{}, []dbModule.Order{}}
-		db.Model(&dbModule.Order{}).Where("status = ?", dbModule.StatusOpen).Where("taker_token = ? AND maker_token = ?", baseTokenAddress, quoteTokenAddress).Order("price, fee_rate, expiration_timestamp_in_sec").Find(&orderBook.Bids)
-		db.Model(&dbModule.Order{}).Where("status = ?", dbModule.StatusOpen).Where("maker_token = ? AND taker_token = ?", baseTokenAddress, quoteTokenAddress).Order("price, fee_rate, expiration_timestamp_in_sec").Find(&orderBook.Asks)
+		db.Model(&dbModule.Order{}).Where("status = ?", dbModule.StatusOpen).Where("expiration_timestamp_in_sec > ?", currentTime).Where("taker_token = ? AND maker_token = ?", baseTokenAddress, quoteTokenAddress).Order("price, fee_rate, expiration_timestamp_in_sec").Find(&orderBook.Bids)
+		db.Model(&dbModule.Order{}).Where("status = ?", dbModule.StatusOpen).Where("expiration_timestamp_in_sec > ?", currentTime).Where("maker_token = ? AND taker_token = ?", baseTokenAddress, quoteTokenAddress).Order("price, fee_rate, expiration_timestamp_in_sec").Find(&orderBook.Asks)
 		response, err := json.Marshal(orderBook)
 		if err != nil {
 			returnError(w, err, 500)

--- a/search/search.go
+++ b/search/search.go
@@ -161,6 +161,7 @@ func SearchHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 			returnError(w, err, 400)
 			return
 		}
+		query = query.Where("expiration_timestamp_in_sec > ?", getExpTime(queryObject))
 		query = query.Offset((pageInt - 1) * perPageInt).Limit(perPageInt)
 		if query.Error != nil {
 			returnError(w, query.Error, 400)

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -185,7 +185,7 @@ func filterContractRequest(queryString, emptyQueryString string, t *testing.T) {
 	}
 	sampleOrder().Save(tx, 0)
 	handler := getTestSearchHandler(tx)
-	request, _ := http.NewRequest("GET", "/v0/orders?"+queryString+"&blockhash=x", nil)
+	request, _ := http.NewRequest("GET", "/v0/orders?"+queryString+"&blockhash=x&_expTime=0", nil)
 	recorder := httptest.NewRecorder()
 	handler(recorder, request)
 	if recorder.Code != 200 {
@@ -261,7 +261,7 @@ func TestPagination(t *testing.T) {
 		saltedSampleOrder().Save(tx, 0)
 	}
 	handler := getTestSearchHandler(tx)
-	request, _ := http.NewRequest("GET", "/v0/orders?&blockhash=x", nil)
+	request, _ := http.NewRequest("GET", "/v0/orders?&blockhash=x&_expTime=0", nil)
 	request.Header.Set("Accept", "application/octet-stream")
 	recorder := httptest.NewRecorder()
 	handler(recorder, request)
@@ -271,7 +271,7 @@ func TestPagination(t *testing.T) {
 	if length := recorder.Body.Len(); length != (20 * 441) {
 		t.Errorf("Expected 20 items, got '%v'", (length / 441))
 	}
-	request, _ = http.NewRequest("GET", "/v0/orders?page=2&blockhash=x", nil)
+	request, _ = http.NewRequest("GET", "/v0/orders?page=2&blockhash=x&_expTime=0", nil)
 	request.Header.Set("Accept", "application/octet-stream")
 	recorder = httptest.NewRecorder()
 	handler(recorder, request)
@@ -366,7 +366,7 @@ func TestOrderBookLookup(t *testing.T) {
 	order := sampleOrder()
 	order.Save(tx, 0)
 	handler := getTestOrderBookHandler(tx)
-	request, _ := http.NewRequest("GET", "/v0/orderbook?blockhash=x&quoteTokenAddress=0x1dad4783cf3fe3085c1426157ab175a6119a04ba&baseTokenAddress=0x05d090b51c40b020eab3bfcb6a2dff130df22e9c", nil)
+	request, _ := http.NewRequest("GET", "/v0/orderbook?blockhash=x&quoteTokenAddress=0x1dad4783cf3fe3085c1426157ab175a6119a04ba&baseTokenAddress=0x05d090b51c40b020eab3bfcb6a2dff130df22e9c&_expTime=0", nil)
 	recorder := httptest.NewRecorder()
 	handler(recorder, request)
 	if recorder.Code != 200 {

--- a/search/util.go
+++ b/search/util.go
@@ -1,0 +1,25 @@
+package search
+
+import (
+	"math/big"
+	"github.com/notegio/openrelay/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	urlModule "net/url"
+	"time"
+)
+
+
+func getExpTime(queryObject urlModule.Values) (*types.Uint256) {
+	var currentTime *big.Int
+
+	if expTimeString := queryObject.Get("_expTime"); expTimeString != "" {
+		currentTime, _ = new(big.Int).SetString(expTimeString, 10)
+	}
+	if currentTime == nil {
+		// _expTime was not set, or was not parseable. Use current time.
+		currentTime = new(big.Int).SetInt64(time.Now().Unix())
+	}
+	currentTimeBytes := &types.Uint256{}
+	copy(currentTimeBytes[:], abi.U256(currentTime))
+	return currentTimeBytes
+}


### PR DESCRIPTION
Addresses #28

Excludes expired orders from search results. To make testing easier,
it adds a url parameter _expTime which can be set to the Unix timestamp
for filtering orders. Any orders that expired prior to _expTime will
be excluded.

