### PR TITLE
Cache balances in the fund checker

### DIFF
--- a/cmd/validateorder/main.go
+++ b/cmd/validateorder/main.go
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating RpcOrderValidator: '%v'", err.Error())
 	}
-	fundChecker, err := funds.NewRpcOrderValidator(rpcURL, feeToken, tokenProxy)
+	fundChecker, err := funds.NewRpcOrderValidator(rpcURL, feeToken, tokenProxy, nil)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/docker-compose-testrpc.yml
+++ b/docker-compose-testrpc.yml
@@ -73,7 +73,7 @@ services:
       context: ./
       dockerfile: Dockerfile.fundcheckrelay
     image: openrelay/fundcheckrelay
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://fundcheck", "queue://delay1", "topic://instant-broadcast"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://fundcheck", "queue://delay1", "topic://instant-broadcast", "--invalidation=topic://newblocks"]
     depends_on:
       - redis
       - ethnode
@@ -173,9 +173,9 @@ services:
   fundcheckrelay2:
     build:
       context: ./
-      dockerfile: Dockerfile.fundcheckrelay
+      dockerfile: Dockerfile.fundcfheckrelay
     image: openrelay/fundcheckrelay
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck2", "queue://preindex"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck2", "queue://preindex", "--invalidation=topic://newblocks"]
     depends_on:
       - ethnode
     restart: on-failure

--- a/funds/mock_balance_checker.go
+++ b/funds/mock_balance_checker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"github.com/notegio/openrelay/types"
+	"github.com/notegio/openrelay/channels"
 	"math/big"
 )
 
@@ -34,6 +35,10 @@ func (funds *mockBalanceChecker) GetAllowance(tokenAddrBytes, userAddrBytes, sen
 	return nil, errors.New("(GetAllowance) Token not found " + hex.EncodeToString(tokenAddrBytes[:]))
 }
 
+func (funds *mockBalanceChecker) Consume(msg channels.Delivery) {
+	msg.Ack()
+}
+
 func NewMockBalanceChecker(balanceMap map[types.Address]map[types.Address]*big.Int) BalanceChecker {
 	return &mockBalanceChecker{balanceMap}
 }
@@ -48,6 +53,10 @@ func (funds *errorMockBalanceChecker) GetBalance(tokenAddrBytes, userAddrBytes *
 
 func (funds *errorMockBalanceChecker) GetAllowance(tokenAddrBytes, userAddrBytes, senderAddress *types.Address) (*big.Int, error) {
 	return nil, funds.err
+}
+
+func (funds *errorMockBalanceChecker) Consume(msg channels.Delivery) {
+	msg.Ack()
 }
 
 func NewErrorMockBalanceChecker(err error) BalanceChecker {

--- a/funds/order_validate.go
+++ b/funds/order_validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/notegio/openrelay/config"
 	"github.com/notegio/openrelay/types"
+	"github.com/notegio/openrelay/channels"
 	"log"
 	"math/big"
 )
@@ -152,8 +153,12 @@ func (funds *orderValidator) ValidateOrder(order *types.Order) (bool, error) {
 	return result, nil
 }
 
-func NewRpcOrderValidator(rpcUrl string, feeToken config.FeeToken, tokenProxy config.TokenProxy) (OrderValidator, error) {
+func NewRpcOrderValidator(rpcUrl string, feeToken config.FeeToken, tokenProxy config.TokenProxy, invalidationChannel channels.ConsumerChannel) (OrderValidator, error) {
 	if checker, err := NewRpcBalanceChecker(rpcUrl); err == nil {
+		if invalidationChannel != nil {
+			invalidationChannel.AddConsumer(checker)
+			invalidationChannel.StartConsuming()
+		}
 		return &orderValidator{checker, feeToken, tokenProxy}, nil
 	} else {
 		return nil, err


### PR DESCRIPTION
In the upcoming embiggen exercise, we will be loading millions of orders
signed by a small set of makers for a single token. Thousands of these orders
will be loaded every block, and there is no chance that a maker's balance
will change between blocks. As such, we can cache balances so long as we
invalidate the cache every time a new block is mined.

Whenever a message comes in on a channel, the cache is reset to an empty map.
The intention is that this channel will be a topic that gets signals every time
a new block is found. When a user's balance or allowance is checked, the result
will be stored in the cache, and it won't need to be rechecked until the next
block.