### PR TITLE
Fix bugs in accounts / affiliate storage

### DIFF
--- a/accounts/account.go
+++ b/accounts/account.go
@@ -6,26 +6,26 @@ import (
 )
 
 type account struct {
-	blacklisted        bool
-	baseFee            *big.Int `json:"-"`
-	discountPercentage int64
-	expiration         int64
+	Bl        bool
+	BaseFee            *big.Int `json:"-"`
+	Dp int64
+	Expiration         int64
 }
 
 func (acct *account) Blacklisted() bool {
-	return acct.blacklisted
+	return acct.Bl
 }
 
 func (acct *account) Discount() *big.Int {
-	if acct.expiration < time.Now().Unix() {
+	if acct.Expiration < time.Now().Unix() {
 		// Account is expired. No discount
 		return new(big.Int)
 	}
 	discount := new(big.Int)
-	discount.Mul(acct.baseFee, big.NewInt(acct.discountPercentage))
+	discount.Mul(acct.BaseFee, big.NewInt(acct.Dp))
 	return discount.Div(discount, big.NewInt(100))
 }
 
-func NewAccount(blacklisted bool, baseFee *big.Int, discountPercentage, expiration int64) Account {
-	return &account{blacklisted, baseFee, discountPercentage, expiration}
+func NewAccount(Bl bool, BaseFee *big.Int, Dp, Expiration int64) Account {
+	return &account{Bl, BaseFee, Dp, Expiration}
 }

--- a/affiliates/affiliate.go
+++ b/affiliates/affiliate.go
@@ -5,13 +5,13 @@ import (
 )
 
 type affiliate struct {
-	baseFee    *big.Int
-	feePercent int64
+	BaseFee    *big.Int
+	FeePercent int64
 }
 
 func (acct *affiliate) Fee() *big.Int {
 	fee := new(big.Int)
-	fee.Mul(acct.baseFee, big.NewInt(acct.feePercent))
+	fee.Mul(acct.BaseFee, big.NewInt(acct.FeePercent))
 	return fee.Div(fee, big.NewInt(100))
 }
 

--- a/affiliates/service.go
+++ b/affiliates/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/notegio/openrelay/types"
 	"gopkg.in/redis.v3"
 	"math/big"
+	"fmt"
 )
 
 type redisAffiliateService struct {
@@ -15,7 +16,7 @@ type redisAffiliateService struct {
 
 func (affiliateService *redisAffiliateService) Get(address *types.Address) (Affiliate, error) {
 	acct := &affiliate{new(big.Int), 100}
-	acctJSON, err := affiliateService.redisClient.Get("affiliate::" + string(address[:])).Result()
+	acctJSON, err := affiliateService.redisClient.Get(fmt.Sprintf("affiliate::%x", address[:])).Result()
 	if err != nil {
 		// Affiliate not found, return the default value
 		return nil, err
@@ -27,7 +28,7 @@ func (affiliateService *redisAffiliateService) Get(address *types.Address) (Affi
 		return nil, err
 	}
 	json.Unmarshal([]byte(acctJSON), acct)
-	acct.baseFee = fee
+	acct.BaseFee = fee
 	return acct, nil
 }
 
@@ -36,7 +37,7 @@ func (affiliateService *redisAffiliateService) Set(address *types.Address, acct 
 	if err != nil {
 		return err
 	}
-	return affiliateService.redisClient.Set("affiliate::"+string(address[:]), string(data), 0).Err()
+	return affiliateService.redisClient.Set(fmt.Sprintf("affiliate::%x", address[:]), string(data), 0).Err()
 }
 
 func NewRedisAffiliateService(redisClient *redis.Client) AffiliateService {

--- a/cmd/setdiscount/main.go
+++ b/cmd/setdiscount/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"encoding/hex"
+	"gopkg.in/redis.v3"
+	"github.com/notegio/openrelay/accounts"
+	"github.com/notegio/openrelay/types"
+	"log"
+	"strconv"
+)
+
+func main() {
+	redisURL := os.Args[1]
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: redisURL,
+	})
+	addrBytes, err := hex.DecodeString(os.Args[2])
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	address := &types.Address{}
+	copy(address[:], addrBytes[:])
+	expiration, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	err = accounts.NewRedisAccountService(redisClient).Set(address, accounts.NewAccount(
+		false,
+		nil,
+		100,
+		int64(expiration),
+	))
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+}


### PR DESCRIPTION
This fixes an issue with the storage of accounts and affiliates.
Both were supposed to be JSON serialized, but because the variables
were private the JSON encoder skipped over them.

I also made the keys for affiliates and accounts use hex encoded
account addresses instead of just passing the raw bytes. Redis is
okay with raw bytes, but it's harder to interact with and inspect
manually.