### PR TITLE
Fix automigrator for mysql

### DIFF
--- a/cmd/automigrate/main.go
+++ b/cmd/automigrate/main.go
@@ -25,26 +25,57 @@ func main() {
 		}
 		username, passwordURI, permissions := creds[0], creds[1], creds[2]
 		password := common.GetSecret(passwordURI)
-		// I don't like using string formatting instead of paramterization, but I
-		// don't know of a way to parameterize the username in this statement. It
-		// should still be fairly safe, because if you're able to execute this
-		// command you already have administrative database access.
-		if err = db.Exec(fmt.Sprintf("CREATE USER %v WITH PASSWORD '%v'", username, password)).Error; err != nil {
-			log.Printf(err.Error())
-		}
-		for _, permission := range(strings.Split(permissions, ",")) {
-			permArray := strings.Split(permission, ".")
-			if len(permArray) != 2 {
-				log.Printf("Malformed permission string '$v'", permission)
-				continue
-			}
-			table, permission := permArray[0], permArray[1]
+		if dialect := db.Dialect().GetName(); dialect == "postgres" {
 			// I don't like using string formatting instead of paramterization, but I
-			// don't know of a way to parameterize the elements in this statement. It
+			// don't know of a way to parameterize the username in this statement. It
 			// should still be fairly safe, because if you're able to execute this
 			// command you already have administrative database access.
-			if err = db.Exec(fmt.Sprintf("GRANT %v ON TABLE %v TO %v", permission, table, username)).Error; err != nil {
+			if err = db.Exec(fmt.Sprintf("CREATE USER %v WITH PASSWORD '%v'", username, password)).Error; err != nil {
 				log.Printf(err.Error())
+			}
+			for _, permission := range(strings.Split(permissions, ",")) {
+				permArray := strings.Split(permission, ".")
+				if len(permArray) != 2 {
+					log.Printf("Malformed permission string '$v'", permission)
+					continue
+				}
+				table, permission := permArray[0], permArray[1]
+				// I don't like using string formatting instead of paramterization, but I
+				// don't know of a way to parameterize the elements in this statement. It
+				// should still be fairly safe, because if you're able to execute this
+				// command you already have administrative database access.
+				if err = db.Exec(fmt.Sprintf("GRANT %v ON TABLE %v TO %v", permission, table, username)).Error; err != nil {
+					log.Printf(err.Error())
+				}
+			}
+		} else if dialect == "mysql" {
+			if err := db.Exec(fmt.Sprintf("CREATE USER '%v' IDENTIFIED BY '%v'", username, password)).Error; err != nil {
+				log.Printf(err.Error())
+			}
+			result := make(map[string]string)
+			if err := db.Exec("SELECT DATABASE()").Row().Scan(result); err != nil {
+				log.Printf(err.Error())
+			}
+			log.Printf("'%v'", result)
+			databaseName := result["DATABASE()"]
+			log.Printf("Database name: %v", databaseName)
+			for _, permission := range(strings.Split(permissions, ",")) {
+				permArray := strings.Split(permission, ".")
+				if len(permArray) != 2 {
+					log.Printf("Malformed permission string '$v'", permission)
+					continue
+				}
+				table, permission := permArray[0], permArray[1]
+				// I don't like using string formatting instead of paramterization, but I
+				// don't know of a way to parameterize the elements in this statement. It
+				// should still be fairly safe, because if you're able to execute this
+				// command you already have administrative database access.
+				if err = db.Exec(fmt.Sprintf("GRANT %v ON %v.%v TO '%v'", permission, databaseName, table, username)).Error; err != nil {
+					log.Printf(err.Error())
+				}
+			}
+			if err := db.Exec("FLUSH PRIVILEGES;").Error; err != nil {
+				log.Printf(err.Error());
 			}
 		}
 		log.Printf("Created '%v'", credString)


### PR DESCRIPTION
While most of the microservices work just fine with MySQL, the automigrator uses some dialect-specific raw SQL that needed to be updated to support MySQL.