### PR TITLE
Use multiple goroutines instead of multiple processes where possible

### DIFF
--- a/channels/consumer.go
+++ b/channels/consumer.go
@@ -15,4 +15,5 @@ type ConsumerChannel interface {
 	StopConsuming() bool
 	ReturnAllUnacked() int
 	PurgeRejected() int
+	Publisher() Publisher
 }

--- a/channels/mock_channel.go
+++ b/channels/mock_channel.go
@@ -11,6 +11,7 @@ type mockConsumerChannel struct {
 	unacked   *deliveries
 	rejected  *deliveries
 	processed uint
+	publisher *mockPublisher
 }
 
 func (mock *mockConsumerChannel) AddConsumer(consumer Consumer) bool {
@@ -55,6 +56,10 @@ func (mock *mockConsumerChannel) PurgeRejected() int {
 	rejected := len(mock.rejected.deliveries)
 	mock.rejected.deliveries = []Delivery{}
 	return rejected
+}
+
+func (mock *mockConsumerChannel) Publisher() Publisher {
+	return mock.publisher
 }
 
 type mockPublisher struct {
@@ -127,6 +132,7 @@ func MockChannel() (Publisher, ConsumerChannel) {
 		unacked,
 		rejected,
 		0,
+		pub,
 	}
 	return pub, consume
 }

--- a/channels/publisher.go
+++ b/channels/publisher.go
@@ -38,3 +38,14 @@ func NewRedisTopicPublisher(key string, client *redis.Client) Publisher {
 func (publisher *redisTopicPublisher) Publish(payload string) bool {
 	return !redisErrIsNil(publisher.redisClient.Publish(publisher.key, payload))
 }
+
+
+type MultiPublisher []Publisher
+
+func (mp MultiPublisher) Publish(payload string) bool {
+	success := true
+	for _, publisher := range mp {
+		success = success && publisher.Publish(payload)
+	}
+	return success
+}

--- a/channels/queue_consumer.go
+++ b/channels/queue_consumer.go
@@ -170,3 +170,7 @@ func (queue *queueConsumerChannel) StopConsuming() bool {
 	}
 	return false
 }
+
+func (queue *queueConsumerChannel) Publisher() Publisher {
+	return NewRedisQueuePublisher(queue.readyKey, queue.redisClient)
+}

--- a/channels/topic_consumer.go
+++ b/channels/topic_consumer.go
@@ -81,3 +81,7 @@ func (topic *topicConsumerChannel) StopConsuming() bool {
 	}
 	return false
 }
+
+func (topic *topicConsumerChannel) Publisher() Publisher {
+	return NewRedisTopicPublisher(topic.channelName, topic.redisClient)
+}

--- a/cmd/cmdutils/utils.go
+++ b/cmd/cmdutils/utils.go
@@ -1,0 +1,35 @@
+package cmdutils
+
+import (
+	"github.com/notegio/openrelay/channels"
+	"strings"
+	"gopkg.in/redis.v3"
+)
+
+// x=>y=>z;q
+
+func ParseChannels(channelString string, redisClient *redis.Client) (channels.ConsumerChannel, channels.MultiPublisher, channels.Publisher, error) {
+	publishers := channels.MultiPublisher{}
+	altPublisherStringSlice := strings.Split(channelString, ";")
+	var altPublisher channels.Publisher
+	if len(altPublisherStringSlice) > 1 {
+		var err error
+		altPublisher, err = channels.PublisherFromURI(altPublisherStringSlice[1], redisClient)
+		if err != nil {
+			return nil, publishers, nil, err
+		}
+	}
+	channelStringSlice := strings.Split(altPublisherStringSlice[0], "=>")
+	sourceChannel, err := channels.ConsumerFromURI(channelStringSlice[0], redisClient)
+	if err != nil {
+		return nil, publishers, nil, err
+	}
+	for _, channelString := range channelStringSlice[1:] {
+		publisher, err := channels.PublisherFromURI(channelString, redisClient)
+		if err != nil {
+			return nil, publishers, nil, err
+		}
+		publishers = append(publishers[:], publisher)
+	}
+	return sourceChannel, publishers, altPublisher, nil
+}

--- a/cmd/delayrelay/main.go
+++ b/cmd/delayrelay/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/notegio/openrelay/channels"
+	"github.com/notegio/openrelay/cmd/cmdutils"
 	"gopkg.in/redis.v3"
 	"os"
 	"os/signal"
@@ -27,53 +28,70 @@ func (consumer *DelayConsumer) Consume(delivery channels.Delivery) {
 
 func main() {
 	redisURL := os.Args[1]
-	src := os.Args[2]
-	dest := os.Args[3]
-	upstreamSignal := os.Args[4]
-	var downstreamSignal string
-	if len(os.Args) >= 6 {
-		downstreamSignal = os.Args[5]
-	} else {
-		downstreamSignal = ""
-	}
+	// src := os.Args[2]
+	// dest := os.Args[3]
+	// upstreamSignal := os.Args[4]
+	// var downstreamSignal string
+	// if len(os.Args) >= 6 {
+	// 	downstreamSignal = os.Args[5]
+	// } else {
+	// 	downstreamSignal = ""
+	// }
 	if redisURL == "" {
 		log.Fatalf("Please specify redis URL")
 	}
-	pubsubClient := redis.NewClient(&redis.Options{
-		Addr: redisURL,
-	})
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: redisURL,
 	})
-	if strings.HasPrefix(src, "topic://") {
-		log.Fatal("Delay relay source must be queue, not topic")
-	}
-	sourceChannel, err := channels.ConsumerFromURI(src, redisClient)
-	if err != nil { log.Fatalf(err.Error())}
-	sourcePublisher, err := channels.PublisherFromURI(src, redisClient)
-	if err != nil { log.Fatalf(err.Error())}
-	destPublisher, err := channels.PublisherFromURI(dest, redisClient)
-	if err != nil { log.Fatalf(err.Error())}
-	signalConsumer, err := channels.ConsumerFromURI(upstreamSignal, pubsubClient)
-	if err != nil { log.Fatalf(err.Error())}
-	var signalPublisher channels.Publisher
-	if downstreamSignal != "" {
-		signalPublisher, err = channels.PublisherFromURI(downstreamSignal, redisClient)
-		if err != nil { log.Fatalf(err.Error())}
-	} else {
-		signalPublisher = nil
+	// if strings.HasPrefix(src, "topic://") {
+	// 	log.Fatal("Delay relay source must be queue, not topic")
+	// }
+	// sourceChannel, err := channels.ConsumerFromURI(src, redisClient)
+	// if err != nil { log.Fatalf(err.Error())}
+	// sourcePublisher, err := channels.PublisherFromURI(src, redisClient)
+	// if err != nil { log.Fatalf(err.Error())}
+	// destPublisher, err := channels.PublisherFromURI(dest, redisClient)
+	// if err != nil { log.Fatalf(err.Error())}
+	// signalConsumer, err := channels.ConsumerFromURI(upstreamSignal, pubsubClient)
+	// if err != nil { log.Fatalf(err.Error())}
+	// var signalPublisher channels.Publisher
+	// if downstreamSignal != "" {
+	// 	signalPublisher, err = channels.PublisherFromURI(downstreamSignal, redisClient)
+	// 	if err != nil { log.Fatalf(err.Error())}
+	// } else {
+	// 	signalPublisher = nil
+	// }
+	var relays []channels.DelayRelay
+	var signalConsumers []channels.ConsumerChannel
+	for _, arg := range os.Args[2:] {
+		channelStrings := strings.Split(arg, ",")
+		if len(channelStrings) != 2 {
+			log.Fatalf("Channel Strings must have two elements separated by ','")
+		}
+		if strings.HasPrefix(channelStrings[1], "topic://") {
+			log.Fatal("Delay relay source must be queue, not topic")
+		}
+		signalConsumer, err := channels.ConsumerFromURI(channelStrings[0], redisClient)
+		sourceChannel, publisher, signalPublisher, err := cmdutils.ParseChannels(channelStrings[1], redisClient)
+		if err != nil { log.Fatalf(err.Error()) }
+		relay := channels.NewDelayRelay(sourceChannel.Publisher(), sourceChannel, publisher, "pause")
+		log.Printf("Starting delayrelay '%v'", arg)
+		relay.Start()
+		signalConsumer.AddConsumer(&DelayConsumer{&relay, signalPublisher})
+		signalConsumer.StartConsuming()
+		relays = append(relays, relay)
+		signalConsumers = append(signalConsumers, signalConsumer)
 	}
 
-	relay := channels.NewDelayRelay(sourcePublisher, sourceChannel, destPublisher, "pause")
-	log.Printf("Starting delayrelay '%v' - '%v'", src, dest)
-	relay.Start()
-	signalConsumer.AddConsumer(&DelayConsumer{&relay, signalPublisher})
-	signalConsumer.StartConsuming()
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	for _ = range c {
 		break
 	}
-	relay.Stop()
-	signalConsumer.StopConsuming()
+	for _, relay := range relays {
+		relay.Stop()
+	}
+	for _, signalConsumer := range signalConsumers {
+		signalConsumer.StopConsuming()
+	}
 }

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -16,9 +16,10 @@ import (
 func main() {
 	redisURL := os.Args[1]
 	defaultFeeRecipientString := os.Args[2]
+	dstChannel := os.Args[3]
 	var port string
-	if len(os.Args) >= 4 {
-		port = os.Args[3]
+	if len(os.Args) >= 5 {
+		port = os.Args[4]
 	} else {
 		port = "8080"
 	}
@@ -36,7 +37,8 @@ func main() {
 	copy(defaultFeeRecipientBytes[:], defaultFeeRecipientSlice[:])
 	affiliateService := affiliates.NewRedisAffiliateService(redisClient)
 	accountService := accounts.NewRedisAccountService(redisClient)
-	publisher := channels.NewRedisQueuePublisher("ingest", redisClient)
+	publisher, err := channels.PublisherFromURI(dstChannel, redisClient)
+	if err != nil { log.Fatalf(err.Error()) }
 	handler := ingest.Handler(publisher, accountService, affiliateService)
 	feeHandler := ingest.FeeHandler(publisher, accountService, affiliateService, defaultFeeRecipientBytes)
 

--- a/cmd/simplerelay/main.go
+++ b/cmd/simplerelay/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/notegio/openrelay/channels"
+	"github.com/notegio/openrelay/cmd/cmdutils"
 	"gopkg.in/redis.v3"
 	"os"
 	"os/signal"
@@ -11,32 +12,45 @@ import (
 
 func main() {
 	redisURL := os.Args[1]
-	src := os.Args[2]
+	// src := os.Args[2]
 	if redisURL == "" {
 		log.Fatalf("Please specify redis URL")
 	}
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: redisURL,
 	})
-	consumerChannel, err := channels.ConsumerFromURI(src, redisClient)
-	if err != nil { log.Fatalf(err.Error())}
-	publishers := []channels.Publisher{}
-	for _, arg := range os.Args[3:] {
-		publisher, err := channels.PublisherFromURI(arg, redisClient)
-		if err != nil { log.Fatalf(err.Error())}
-		publishers = append(publishers, publisher)
-	}
 	concurrency, err := strconv.Atoi(os.Getenv("CONCURRENCY"))
 	if err != nil {
 		concurrency = 5
 	}
-	relay := channels.NewRelay(consumerChannel, publishers, &channels.IncludeAll{}, concurrency)
-	log.Printf("Starting simple relay '%v' -> '%v'", src, os.Args[3:])
-	relay.Start()
+	var relays []channels.Relay
+	for _, channelString := range os.Args[2:] {
+		consumerChannel, publisher, _, err := cmdutils.ParseChannels(channelString, redisClient)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		relay := channels.NewRelay(consumerChannel, publisher, &channels.IncludeAll{}, concurrency)
+		log.Printf("Starting simple relay '%v'", channelString)
+		relay.Start()
+		relays = append(relays, relay)
+	}
+	// consumerChannel, err := channels.ConsumerFromURI(src, redisClient)
+	// if err != nil { log.Fatalf(err.Error())}
+	// publishers := []channels.Publisher{}
+	// for _, arg := range os.Args[3:] {
+	// 	publisher, err := channels.PublisherFromURI(arg, redisClient)
+	// 	if err != nil { log.Fatalf(err.Error())}
+	// 	publishers = append(publishers, publisher)
+	// }
+	// relay := channels.NewRelay(consumerChannel, publishers, &channels.IncludeAll{}, concurrency)
+	// log.Printf("Starting simple relay '%v' -> '%v'", src, os.Args[3:])
+	// relay.Start()
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	for _ = range c {
 		break
 	}
-	relay.Stop()
+	for _, relay := range relays {
+		relay.Stop()
+	}
 }

--- a/docker-compose-testrpc.yml
+++ b/docker-compose-testrpc.yml
@@ -36,7 +36,7 @@ services:
     image: "openrelay/ingest:${TAG:-latest}"
     ports:
       - "8081:8080"
-    command: ["/ingest", "${REDIS_HOST:-redis:6379}", "C22d5b2951DB72B44CFb8089bb8CD374A3c354eA"]
+    command: ["/ingest", "${REDIS_HOST:-redis:6379}", "C22d5b2951DB72B44CFb8089bb8CD374A3c354eA", "queue://ingest"]
     depends_on:
       - redis
     deploy:
@@ -60,7 +60,7 @@ services:
       context: ./
       dockerfile: Dockerfile.fillupdate
     image: "openrelay/fillupdate:${TAG:-latest}"
-    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://fillupdate", "topic://ordersfilled", "file:///bloom/data/testdata", "queue://fundcheck"]
+    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "topic://ordersfilled", "file:///bloom/data/testdata", "queue://fillupdate=>queue://fundcheck", "queue://recheck=>queue://recheck2"]
     volumes:
       - bloomdata:/bloom/data
     depends_on:
@@ -75,7 +75,7 @@ services:
       context: ./
       dockerfile: Dockerfile.fundcheckrelay
     image: "openrelay/fundcheckrelay:${TAG:-latest}"
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://fundcheck", "queue://delay1", "topic://instant-broadcast", "--invalidation=topic://newblocks"]
+    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://fundcheck=>queue://delay1=>topic://instant-broadcast", "queue://recheck2=>queue://pgindexer", "--invalidation=topic://newblocks"]
     depends_on:
       - redis
       - ethnode
@@ -89,25 +89,25 @@ services:
       context: ./
       dockerfile: Dockerfile.delayrelay
     image: "openrelay/delayrelay:${TAG:-latest}"
-    command: ["/delayrelay", "${REDIS_HOST:-redis:6379}", "queue://delay1", "queue://delay2", "topic://delay1trigger"]
+    command: ["/delayrelay", "${REDIS_HOST:-redis:6379}", "topic://delay1trigger,queue://delay1=>queue://delay2", "topic://newblocks,queue://delay2=>queue://recheck=>topic://released-broadcast;topic://delay1trigger"]
     depends_on:
       - redis
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
-  delayrelay2:
-    build:
-      context: ./
-      dockerfile: Dockerfile.delayrelay
-    image: "openrelay/delayrelay:${TAG:-latest}"
-    command: ["/delayrelay", "${REDIS_HOST:-redis:6379}", "queue://delay2", "queue://released", "topic://newblocks", "topic://delay1trigger"]
-    depends_on:
-      - redis
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
+  # delayrelay2:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile.delayrelay
+  #   image: "openrelay/delayrelay:${TAG:-latest}"
+  #   command: ["/delayrelay", "${REDIS_HOST:-redis:6379}", "queue://delay2", "queue://released", "topic://newblocks", "topic://delay1trigger"]
+  #   depends_on:
+  #     - redis
+  #   deploy:
+  #     replicas: 1
+  #     restart_policy:
+  #       condition: on-failure
   fillmonitor:
     build:
       context: ./
@@ -149,42 +149,42 @@ services:
       POSTGRES_PASSWORD: secret
     restart: on-failure
 
-  simplerelayreleased:
-    build:
-      context: ./
-      dockerfile: Dockerfile.simplerelay
-    image: "openrelay/simplerelay:${TAG:-latest}"
-    command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://released", "queue://recheck", "topic://released-broadcast"]
-    depends_on:
-      - redis
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
-  fillupdate2:
-    build:
-      context: ./
-      dockerfile: Dockerfile.fillupdate
-    image: "openrelay/fillupdate:${TAG:-latest}"
-    command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck", "topic://ordersfilled", "file:///bloom/data/testdata", "queue://recheck2"]
-    volumes:
-      - bloomdata:/bloom/data
-    depends_on:
-      - redis
-      - ethnode
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
-  fundcheckrelay2:
-    build:
-      context: ./
-      dockerfile: Dockerfile.fundcheckrelay
-    image: "openrelay/fundcheckrelay:${TAG:-latest}"
-    command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck2", "queue://pgindexer", "--invalidation=topic://newblocks"]
-    depends_on:
-      - ethnode
-    restart: on-failure
+  # simplerelayreleased:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile.simplerelay
+  #   image: "openrelay/simplerelay:${TAG:-latest}"
+  #   command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://released", "queue://recheck", "topic://released-broadcast"]
+  #   depends_on:
+  #     - redis
+  #   deploy:
+  #     replicas: 1
+  #     restart_policy:
+  #       condition: on-failure
+  # fillupdate2:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile.fillupdate
+  #   image: "openrelay/fillupdate:${TAG:-latest}"
+  #   command: ["/fillupdate", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck", "topic://ordersfilled", "file:///bloom/data/testdata", "queue://recheck2"]
+  #   volumes:
+  #     - bloomdata:/bloom/data
+  #   depends_on:
+  #     - redis
+  #     - ethnode
+  #   deploy:
+  #     replicas: 1
+  #     restart_policy:
+  #       condition: on-failure
+  # fundcheckrelay2:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile.fundcheckrelay
+  #   image: "openrelay/fundcheckrelay:${TAG:-latest}"
+  #   command: ["/fundcheckrelay", "${REDIS_HOST:-redis:6379}", "${ETHEREUM_STATE_NODE:-http://ethnode:8545}", "queue://recheck2", "queue://pgindexer", "--invalidation=topic://newblocks"]
+  #   depends_on:
+  #     - ethnode
+  #   restart: on-failure
   initialize:
     build:
       context: ./
@@ -252,12 +252,12 @@ services:
       restart_policy:
         condition: on-failure
     restart: on-failure
-  simplerelayfillindexer:
+  simplerelay:
     build:
       context: ./
       dockerfile: Dockerfile.simplerelay
     image: "openrelay/simplerelay:${TAG:-latest}"
-    command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://ordersfilled", "queue://pgordersfilled", "topic://ordersfilled"]
+    command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://ordersfilled=>queue://pgordersfilled=>topic://ordersfilled", "queue://newblocks=>queue://allowanceblocks=>queue://spendblocks=>topic://newblocks=>queue://fillblocks"]
     depends_on:
       - redis
     deploy:
@@ -280,18 +280,18 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-  simplerelaynewblocks:
-    build:
-      context: ./
-      dockerfile: Dockerfile.simplerelay
-    image: "openrelay/simplerelay:${TAG:-latest}"
-    command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://newblocks", "queue://allowanceblocks", "queue://spendblocks", "topic://newblocks", "queue://fillblocks"]
-    depends_on:
-      - redis
-    deploy:
-      replicas: 1
-      restart_policy:
-        condition: on-failure
+  # simplerelaynewblocks:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile.simplerelay
+  #   image: "openrelay/simplerelay:${TAG:-latest}"
+  #   command: ["/simplerelay", "${REDIS_HOST:-redis:6379}", "queue://newblocks", "queue://allowanceblocks", "queue://spendblocks", "topic://newblocks", "queue://fillblocks"]
+  #   depends_on:
+  #     - redis
+  #   deploy:
+  #     replicas: 1
+  #     restart_policy:
+  #       condition: on-failure
   allowancemonitor:
     build:
       context: ./


### PR DESCRIPTION
For the fundchecker, fillupdater, delayrelay, and simplerelay, we have
been running multiple processes with each pulling from a single source
channel and publishing to one or more destinations channels.

This change lets us specify groups of sources and destinations, and a
single process can have multiple sources each with their own set of destinations.
Each source is managed by its own goroutine (or set of goroutines), but other
resources are shared where possible. This should reduce the over-all footprint
of many services, as they move from being multiple containers to single containers
with multiple goroutines.