### PR TITLE
Spend monitor improvements

### DIFF
--- a/monitor/spend/spend.go
+++ b/monitor/spend/spend.go
@@ -75,7 +75,7 @@ func (consumer *spendBlockConsumer) Consume(delivery channels.Delivery) {
 					allowance = big.NewInt(0)
 				} else {
 					delivery.Return()
-					log.Fatalf("Failed to get balance")
+					log.Fatalf("Failed to get allowance for '%v' - '%v': %v", tokenAddress, senderAddress, err.Error())
 				}
 			}
 			if allowance.Cmp(big.NewInt(0)) == 0 {
@@ -90,7 +90,7 @@ func (consumer *spendBlockConsumer) Consume(delivery channels.Delivery) {
 						balance = big.NewInt(0)
 						} else {
 							delivery.Return()
-							log.Fatalf("Failed to get balance: %v", err.Error())
+							log.Fatalf("Failed to get balance for '%v' - '%v': %v", tokenAddress, senderAddress, err.Error())
 						}
 					}
 					if allowance.Cmp(balance) < 0 {

--- a/monitor/spend/spend.go
+++ b/monitor/spend/spend.go
@@ -57,7 +57,7 @@ func (consumer *spendBlockConsumer) Consume(delivery channels.Delivery) {
 		for _, spendLog := range logs {
 			senderAddress := &types.Address{}
 			tokenAddress := &types.Address{}
-			copy(senderAddress[:], spendLog.Topics[2][12:])
+			copy(senderAddress[:], spendLog.Topics[1][12:])
 			copy(tokenAddress[:], spendLog.Address[:])
 			pairKey := fmt.Sprintf("%#x:%#x", senderAddress, tokenAddress)
 			if _, ok := tradedTokens[pairKey]; ok {

--- a/monitor/spend/spend_test.go
+++ b/monitor/spend/spend_test.go
@@ -94,7 +94,7 @@ func TestSpendFromBlock(t *testing.T) {
 	copy(tokenProxyAddress[:], tokenProxyBytes[:])
 	tokenBytes := common.HexToAddress("0x3495ffcee09012ab7d827abf3e3b3ae428a38443")
 	tokenAddress := &orTypes.Address{}
-	spenderBytes := common.HexToAddress("0x12459c951127e0c374ff9105dda097662a027093")
+	spenderBytes := common.HexToAddress("0x34ab4a96678c4de8eb34597dbbcf09c27d9bc79d")
 	spenderAddress := &orTypes.Address{}
 	copy(tokenAddress[:], tokenBytes[:])
 	copy(spenderAddress[:], spenderBytes[:])


### PR DESCRIPTION
The spend monitor had a heinous bug where it was reporting the balance of the recipient of a transfer as the balance of the sender. This could have lead to some significant problems in the orderbook if it hadn't been caught before the Embiggen airdrop launch.