### PR TITLE
Use Docker Multistage Builds

### DIFF
--- a/Dockerfile.allowancemonitor
+++ b/Dockerfile.allowancemonitor
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/allowancemonitor /allowancemonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/allowancemonitor /allowancemonitor
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.automigrate
+++ b/Dockerfile.automigrate
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/automigrate /automigrate
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/automigrate /automigrate
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.blockmonitorng
+++ b/Dockerfile.blockmonitorng
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/blockmonitor /blockmonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/blockmonitor /blockmonitor
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.delayrelay
+++ b/Dockerfile.delayrelay
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/delayrelay /delayrelay
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/delayrelay /delayrelay
 
 CMD ["/delayrelay"]

--- a/Dockerfile.exchangesplitter
+++ b/Dockerfile.exchangesplitter
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/exchangesplitter /exchangesplitter
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/exchangesplitter /exchangesplitter
 
 CMD ["/exchangesplitter"]

--- a/Dockerfile.fillmonitorng
+++ b/Dockerfile.fillmonitorng
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/fillmonitor /fillmonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/fillmonitor /fillmonitor
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.fillupdate
+++ b/Dockerfile.fillupdate
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/fillupdate /fillupdate
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/fillupdate /fillupdate
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.fundcheckrelay
+++ b/Dockerfile.fundcheckrelay
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/fundcheckrelay /fundcheckrelay
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/fundcheckrelay /fundcheckrelay
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.getbalance
+++ b/Dockerfile.getbalance
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/getbalance /getbalance
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/getbalance /getbalance
 
 CMD ["/getbalance"]

--- a/Dockerfile.ingest
+++ b/Dockerfile.ingest
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/ingest /ingest
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/ingest /ingest
 
 CMD ["/ingest"]

--- a/Dockerfile.initialize
+++ b/Dockerfile.initialize
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/initialize /initialize
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/initialize /initialize
 
 CMD ["/initialize"]

--- a/Dockerfile.multisigmonitor
+++ b/Dockerfile.multisigmonitor
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/multisigmonitor /multisigmonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/multisigmonitor /multisigmonitor
 
 CMD ["/multisigmonitor", "redis:6379", "ethnode:8545", "queue://newblocks", "0x48bacb9266a570d521063ef5dd96e61686dbe788"]

--- a/Dockerfile.pgfillindexer
+++ b/Dockerfile.pgfillindexer
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/fillindexer /fillindexer
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/fillindexer /fillindexer
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.pgindexer
+++ b/Dockerfile.pgindexer
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/indexer /indexer
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/indexer /indexer
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.pgsearchapi
+++ b/Dockerfile.pgsearchapi
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/searchapi /searchapi
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/searchapi /searchapi
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.queuemonitor
+++ b/Dockerfile.queuemonitor
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/queuemonitor /queuemonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/queuemonitor /queuemonitor
 
 CMD ["/queuemonitor", "redis:6379", "1", "newblocks-ropsten"]

--- a/Dockerfile.simplerelay
+++ b/Dockerfile.simplerelay
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/simplerelay /simplerelay
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/simplerelay /simplerelay
 
 CMD ["/simplerelay"]

--- a/Dockerfile.spendmonitor
+++ b/Dockerfile.spendmonitor
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/spendmonitor /spendmonitor
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/spendmonitor /spendmonitor
 
 CMD ["/spendmonitor", "redis:6379", "ethnode:8545", "queue://newblocks", "queue://recordspend", "0x48bacb9266a570d521063ef5dd96e61686dbe788"]

--- a/Dockerfile.spendrecorder
+++ b/Dockerfile.spendrecorder
@@ -1,6 +1,16 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/spendrecorder /spendrecorder
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/spendrecorder /spendrecorder
 
 COPY docker-cfg/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.validateorder
+++ b/Dockerfile.validateorder
@@ -1,5 +1,15 @@
+FROM golang:1.8 as corebuild
+
+RUN mkdir -p /go/src/github.com/notegio/openrelay
+
+WORKDIR /go/src/github.com/notegio/openrelay
+
+COPY . .
+
+RUN make clean bin
+
 FROM scratch
 
-COPY bin/validateorder /validateorder
+COPY --from=corebuild /go/src/github.com/notegio/openrelay/bin/validateorder /validateorder
 
 CMD ["/validateorder"]


### PR DESCRIPTION
Historically, building the docker images has required doing a build
on your local system, then pulling the build artifacts into your images.
This raises the bar for getting your own system up and running, as it
requires you to have a go development environment set up, Gopath configured,
etc. It also causes problems if the builder is not running Linux, as
binaries built on Windows or Mac won't work within a Docker container.

This executes the Go bulid in Docker, then copies the artifacts into the
respective containers. Each dockerfile lists out the build steps, but
since they're the same in every Dockerfile the build steps get cached
and the Go build only has to be executed once. From what I can tell,
the alternative is to have a separate build image that keeps all the
artifacts, require people to build that first, then pull from the named
image to get the artifacts. With the current implementation, just running
"docker-compose -f docker-compose-testrpc.yml build" will compile
everything in one shot so we're ready to go.