### PR TITLE
Fix order_config API to align with standard relayer API

### DIFF
--- a/ingest/fee_info.go
+++ b/ingest/fee_info.go
@@ -17,16 +17,16 @@ import (
 // Everything else will be ignored.
 type FeeInputPayload struct {
 	Maker        string `json:"maker"`
-	FeeRecipient string `json:"feeRecipient"`
+	FeeRecipient string `json:"feeRecipientAddress"`
 	Taker        string `json:"taker"`
-	Sender       string `json:"sender"`
+	Sender       string `json:"senderAddress"`
 }
 
 type FeeResponse struct {
 	MakerFee       string `json:"makerFee"`
 	TakerFee       string `json:"takerFee"`
-	FeeRecipient   string `json:"feeRecipient"`
-	Sender         string `json:"sender"`
+	FeeRecipient   string `json:"feeRecipientAddress"`
+	Sender         string `json:"senderAddress"`
 	TakerToSpecify string `json:"takerToSpecify"`
 }
 

--- a/ingest/fee_info_test.go
+++ b/ingest/fee_info_test.go
@@ -15,7 +15,7 @@ func TestFeeRecipientAndMakerProvided(t *testing.T) {
 	publisher := TestPublisher{}
 	handler := ingest.FeeHandler(&publisher, &TestAccountService{false, new(big.Int)}, &TestAffiliateService{new(big.Int), nil}, [20]byte{})
 	reader := TestReader{
-		[]byte("{\"maker\": \"0x0000000000000000000000000000000000000000\", \"feeRecipient\": \"0000000000000000000000000000000000000000\", \"takerTokenAmount\": \"100\", \"makerTokenAmount\": \"100\"}"),
+		[]byte("{\"maker\": \"0x0000000000000000000000000000000000000000\", \"feeRecipientAddress\": \"0000000000000000000000000000000000000000\", \"takerTokenAmount\": \"100\", \"makerTokenAmount\": \"100\"}"),
 		nil,
 	}
 	request, _ := http.NewRequest("POST", "/v0.0/fees", reader)
@@ -27,7 +27,7 @@ func TestFeeRecipientAndMakerProvided(t *testing.T) {
 		t.Errorf("Body: '%v'", recorder.Body.String())
 	}
 	body := recorder.Body.String()
-	if body != "{\"makerFee\":\"0\",\"takerFee\":\"0\",\"feeRecipient\":\"0x0000000000000000000000000000000000000000\",\"sender\":\"0x0000000000000000000000000000000000000000\",\"takerToSpecify\":\"0x0000000000000000000000000000000000000000\"}" {
+	if body != "{\"makerFee\":\"0\",\"takerFee\":\"0\",\"feeRecipientAddress\":\"0x0000000000000000000000000000000000000000\",\"senderAddress\":\"0x0000000000000000000000000000000000000000\",\"takerToSpecify\":\"0x0000000000000000000000000000000000000000\"}" {
 		t.Errorf("Unexpected body: '%v'", body)
 	}
 }
@@ -47,7 +47,7 @@ func TestFeeRecipientAndMakerDefault(t *testing.T) {
 		t.Errorf("Body: '%v'", recorder.Body.String())
 	}
 	body := recorder.Body.String()
-	if body != "{\"makerFee\":\"0\",\"takerFee\":\"0\",\"feeRecipient\":\"0x0000000000000000000000000000000000000000\",\"sender\":\"0x0000000000000000000000000000000000000000\",\"takerToSpecify\":\"0x0000000000000000000000000000000000000000\"}" {
+	if body != "{\"makerFee\":\"0\",\"takerFee\":\"0\",\"feeRecipientAddress\":\"0x0000000000000000000000000000000000000000\",\"senderAddress\":\"0x0000000000000000000000000000000000000000\",\"takerToSpecify\":\"0x0000000000000000000000000000000000000000\"}" {
 		t.Errorf("Unexpected body: '%v'", body)
 	}
 }


### PR DESCRIPTION
Apparently we missed a couple of points with regard to the standard relayer API compliance on order_info.