### PR TITLE
It turns out that Bloom.Test() doesn't actually work with Ethereum

### DIFF
--- a/monitor/affiliate/affiliate.go
+++ b/monitor/affiliate/affiliate.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/notegio/openrelay/channels"
 	"github.com/notegio/openrelay/types"
@@ -29,7 +30,7 @@ func (consumer *affiliateBlockConsumer) Consume(delivery channels.Delivery) {
 	}
 	affiliateTopic := &big.Int{}
 	affiliateTopic.SetString("60dad0d232381238c031553102e3a2d779bda5a9507ec806820542b3da2801eb", 16)
-	if block.Bloom.Test(consumer.affiliateSignupAddress) && block.Bloom.Test(affiliateTopic) {
+	if coreTypes.BloomLookup(block.Bloom, consumer.affiliateSignupAddress) && coreTypes.BloomLookup(block.Bloom, affiliateTopic) {
 		query := ethereum.FilterQuery{
 			FromBlock: block.Number,
 			ToBlock: block.Number,

--- a/monitor/allowance/allowance.go
+++ b/monitor/allowance/allowance.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	// "github.com/ethereum/go-ethereum/core/types"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	// "github.com/notegio/openrelay/funds"
 	"github.com/notegio/openrelay/channels"
 	"github.com/notegio/openrelay/db"
@@ -32,7 +32,7 @@ func (consumer *allowanceBlockConsumer) Consume(delivery channels.Delivery) {
 	if err != nil {
 		log.Printf("Error parsing payload: %v\n", err.Error())
 	}
-	if block.Bloom.Test(consumer.approvalTopic) && block.Bloom.Test(consumer.tokenProxyAddress) {
+	if coreTypes.BloomLookup(block.Bloom, consumer.approvalTopic) && coreTypes.BloomLookup(block.Bloom, common.BigToHash(consumer.tokenProxyAddress)) {
 		log.Printf("Block %#x bloom filter indicates approval event for %#x", block.Hash, consumer.tokenProxyAddress)
 		query := ethereum.FilterQuery{
 			FromBlock: block.Number,

--- a/monitor/allowance/allowance_test.go
+++ b/monitor/allowance/allowance_test.go
@@ -57,24 +57,20 @@ func TestBloom(t *testing.T) {
 	approvalTopic.SetString("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", 16)
 	proxyAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48").Big()
 	bloom := types.BytesToBloom(bloomBytes)
-	if !bloom.Test(approvalTopic) {
+	if !types.BloomLookup(bloom, approvalTopic) {
 		t.Errorf("Bloom filter didn't match approval")
 	}
-	if !bloom.Test(proxyAddress) {
+	if !types.BloomLookup(bloom, proxyAddress) {
 		t.Errorf("Bloom filter didn't match proxy")
 	}
-	if bloom.Test(&big.Int{}) {
+	if types.BloomLookup(bloom, &big.Int{}) {
 		t.Errorf("Bloom filter shouldn't have matched empty integer")
 	}
 }
 
 func TestAllowanceFromBlock(t *testing.T) {
 	testLog := allowanceLog()
-	bloom := types.Bloom{}
-	bloom.Add(new(big.Int).SetBytes(testLog.Address[:]))
-	for _, topic := range testLog.Topics {
-		bloom.Add(new(big.Int).SetBytes(topic[:]))
-	}
+	bloom := types.BytesToBloom(types.LogsBloom([]*types.Log{testLog}).Bytes())
 	mb := &blocks.MiniBlock{
 		common.Hash{},
 		big.NewInt(0),

--- a/monitor/fill/fill.go
+++ b/monitor/fill/fill.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	// "github.com/ethereum/go-ethereum/core/types"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	// "github.com/notegio/openrelay/funds"
 	"github.com/notegio/openrelay/fillbloom"
 	"github.com/notegio/openrelay/channels"
@@ -41,7 +41,7 @@ func (consumer *fillBlockConsumer) Consume(delivery channels.Delivery) {
 			log.Fatalf("Failed to initialize bloom filter: %v", err.Error())
 		}
 	}
-	if (block.Bloom.Test(consumer.fillTopic) || block.Bloom.Test(consumer.cancelTopic)) && block.Bloom.Test(consumer.exchangeAddress) {
+	if (coreTypes.BloomLookup(block.Bloom, consumer.fillTopic) || coreTypes.BloomLookup(block.Bloom, consumer.cancelTopic)) && coreTypes.BloomLookup(block.Bloom, consumer.exchangeAddress) {
 		log.Printf("Block %#x bloom filter indicates fill event for %#x", block.Hash, consumer.exchangeAddress)
 		query := ethereum.FilterQuery{
 			FromBlock: block.Number,

--- a/monitor/fill/fill_test.go
+++ b/monitor/fill/fill_test.go
@@ -60,11 +60,7 @@ func TestFillFromBlock(t *testing.T) {
 	os.Mkdir(directory, 0755)
 	itemURL := fmt.Sprintf("file://%v/test", directory)
 	testLog := fillLog()
-	bloom := types.Bloom{}
-	bloom.Add(new(big.Int).SetBytes(testLog.Address[:]))
-	for _, topic := range testLog.Topics {
-		bloom.Add(new(big.Int).SetBytes(topic[:]))
-	}
+	bloom := types.BytesToBloom(types.LogsBloom([]*types.Log{testLog}).Bytes())
 	mb := &blocks.MiniBlock{
 		common.Hash{},
 		big.NewInt(0),

--- a/monitor/spend/spend.go
+++ b/monitor/spend/spend.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	// "github.com/ethereum/go-ethereum/core/types"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/notegio/openrelay/funds"
 	"github.com/notegio/openrelay/channels"
 	"github.com/notegio/openrelay/db"
@@ -35,7 +35,7 @@ func (consumer *spendBlockConsumer) Consume(delivery channels.Delivery) {
 	if err != nil {
 		log.Printf("Error parsing payload: %v\n", err.Error())
 	}
-	if block.Bloom.Test(consumer.spendTopic) {
+	if coreTypes.BloomLookup(block.Bloom, consumer.spendTopic) {
 		log.Printf("Block %#x bloom filter indicates spend event", block.Hash)
 		query := ethereum.FilterQuery{
 			FromBlock: block.Number,

--- a/monitor/spend/spend_test.go
+++ b/monitor/spend/spend_test.go
@@ -69,11 +69,7 @@ func TestBloom(t *testing.T) {
 
 func TestSpendFromBlock(t *testing.T) {
 	testLog := spendLog()
-	bloom := types.Bloom{}
-	bloom.Add(new(big.Int).SetBytes(testLog.Address[:]))
-	for _, topic := range testLog.Topics {
-		bloom.Add(new(big.Int).SetBytes(topic[:]))
-	}
+	bloom := types.BytesToBloom(types.LogsBloom([]*types.Log{testLog}).Bytes())
 	mb := &blocks.MiniBlock{
 		common.Hash{},
 		big.NewInt(0),


### PR DESCRIPTION
bloom filters if any of the topics have leading 0 bytes. That issue
is documented here: https://github.com/ethereum/go-ethereum/issues/18092

This switches to using the BloomLookup() method, which works correctly.

The only place this was actually a problem was the approvals monitors.
All of the others only relied on topics that were 32 bytes instead of
20 or less.