### PR TITLE
Add cache control to errors on TOS

### DIFF
--- a/terms/terms.go
+++ b/terms/terms.go
@@ -41,6 +41,7 @@ type IngestError struct {
 func returnError(w http.ResponseWriter, errResp IngestError, status int) {
 	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	errBytes, err := json.Marshal(errResp)
 	if err != nil {
 		log.Printf(err.Error())


### PR DESCRIPTION
We found that when dApps query for whether an account is authorized,
cloudfront caches the answer. After they authorize, the dApp asks again,
and cloudfront returns the cached "no they don't exist" even though
the authorization changed the correct answer.

We're making error pages uncacheable here, which we should consider
doing for other endpoints as well.