### PR TITLE
WriteHeader must be after Header().Set()

### DIFF
--- a/ingest/fee_info.go
+++ b/ingest/fee_info.go
@@ -139,8 +139,8 @@ func FeeHandler(publisher channels.Publisher, accounts accountsModule.AccountSer
 			senderToSpecify,
 			takerToSpecify,
 		}
-		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
 		feeBytes, err := json.Marshal(feeResponse)
 		if err != nil {
 			log.Printf(err.Error())

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -39,8 +39,8 @@ func valInList(val *types.Address, list []types.Address) bool {
 }
 
 func returnError(w http.ResponseWriter, errResp IngestError, status int) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	errBytes, err := json.Marshal(errResp)
 	if err != nil {
 		log.Printf(err.Error())
@@ -53,8 +53,8 @@ func Handler(publisher channels.Publisher, accounts accountsModule.AccountServic
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
 			// Health checks
-			w.WriteHeader(200)
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
 			fmt.Fprintf(w, "{\"ok\": true}")
 			return
 		}

--- a/search/search.go
+++ b/search/search.go
@@ -111,15 +111,15 @@ func applyOrFilter(query *gorm.DB, queryField, dbField1, dbField2 string, queryO
 }
 
 func returnError(w http.ResponseWriter, err error, code int) {
-	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
 	w.Write([]byte(fmt.Sprintf("{\"code\":100,\"reason\":\"%v\"}", err.Error())))
 }
 
 func returnErrorList(w http.ResponseWriter, errs []ValidationError) {
-	w.WriteHeader(400)
 	apiError := ApiError{100, "Validation Failed", errs}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
 	data, err := json.Marshal(apiError)
 	if err == nil {
 		w.Write(data)
@@ -306,7 +306,6 @@ func SearchHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 		}
 		response, contentType, err := FormatResponse(orders, acceptHeader, count, pageInt, perPageInt)
 		if err == nil {
-			w.WriteHeader(200)
 
 
 			url := *r.URL
@@ -315,6 +314,7 @@ func SearchHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 
 			w.Header().Set("Link", fmt.Sprintf("<%v>; rel=\"next\"", (&url).RequestURI()))
 			w.Header().Set("Content-Type", contentType)
+			w.WriteHeader(200)
 			w.Write(response)
 		} else {
 			returnError(w, err, 500)

--- a/terms/terms.go
+++ b/terms/terms.go
@@ -39,9 +39,9 @@ type IngestError struct {
 
 
 func returnError(w http.ResponseWriter, errResp IngestError, status int) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.WriteHeader(status)
 	errBytes, err := json.Marshal(errResp)
 	if err != nil {
 		log.Printf(err.Error())
@@ -80,12 +80,12 @@ func TermsHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 				returnError(w, IngestError{101, err.Error()}, 500)
 				return
 			}
-			w.WriteHeader(200)
 			w.Header().Set("Content-Type", "application/json")
 			// The hashmask we're returning will in 30 - 60 minutes. Setting a max
 			// age of 25 minutes ensures anything served from cloudfront is good for
 			// at least 5 minutes.
 			w.Header().Set("Cache-Control", "max-age=1500, public")
+			w.WriteHeader(200)
 			w.Write(data)
 		} else if r.Method == "POST" {
 			var data [1024]byte


### PR DESCRIPTION
Apparently w.WriteHeader() makes w.Header() read-only. In several
places we were doing this out of order. Our recent change to cache
control directives made this apparent, but I've fixed it in several
other places as well.