### PR TITLE
Change CORS implementation for search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     depends_on:
       - redis
       - corebuild
+    restart: on-failure
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
This puts a slightly more naive implementation of CORS in place for
the search API. Since the search API only handles GET requests, and
all resources are uncredentialed and public, we can serve with
"Access-Control-Allow-Origin: *" for all requests.

We were seeing issues with cloudfront ignoring rs/cors vary header,
while the Access-Control-Allow-Origin header was only injected if the
request provied an "Origin" header. That meant that if the same resource
was requested without the Origin header, and again later with the Origin
header, the second response would not have the "Access-Control-Allow-Origin"
header present and the browser would reject it.

The other APIs deal primarily with POST requests. Those still use rs/cors,
as CORS for post requests is more complicated, and POST requests also don't
get cached by cloudfront.