### PR TITLE
Make fillbloom initializer chunk size configurable

### DIFF
--- a/blockhash/blockhash.go
+++ b/blockhash/blockhash.go
@@ -27,7 +27,7 @@ func (rbhc *ChanneledBlockHashConsumer) Consume(delivery channels.Delivery) {
 	payload := []byte(delivery.Payload())
 	err := json.Unmarshal(payload, block)
 	if err != nil {
-		log.Printf("Error Parsing Payload: %v", err.Error())
+		log.Printf("Error Parsing Payload: %v - '%v'", err.Error(), string(payload))
 		delivery.Reject()
 		return
 	}


### PR DESCRIPTION
We're getting timeouts trying to scan 100,000 blocks at a time for
fill records. This makes it configurable, and lowers the default.
It also fixes a formatting error in the output.