### PR TITLE
SRA Compliance: perPage, not per_page

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -78,7 +78,10 @@ func getPages(queryObject urlModule.Values) (int, int, error) {
 	if pageStr == "" {
 		pageStr = "1"
 	}
-	perPageStr := queryObject.Get("per_page")
+	perPageStr := queryObject.Get("perPage")
+	if perPageStr == "" {
+		perPageStr = queryObject.Get("per_page")
+	}
 	if perPageStr == "" {
 		perPageStr = "20"
 	}


### PR DESCRIPTION
SRA v0 used per_page for pagination, SRA v2 uses perPage. We'll
continue to support per_page, since that has worked since we've
been on v2, but will also support the spec compliant perPage.