### PR TITLE
Use text data type instead of binary

### DIFF
--- a/channels/ws/ws.go
+++ b/channels/ws/ws.go
@@ -122,7 +122,7 @@ func GetChannels(port uint, db *gorm.DB, cleanup func(channels.Publisher)) (<-ch
 		for {
 			select {
 			case payload := <- wsChannel.payloads:
-				if err := conn.WriteMessage(websocket.BinaryMessage, payload); err != nil {
+				if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
 					log.Println(err)
 					return
 				}

--- a/channels/ws/ws_test.go
+++ b/channels/ws/ws_test.go
@@ -40,14 +40,14 @@ func TestGetChannels(t *testing.T) {
 		resp.Body.Read(content[:])
 		t.Fatalf("%v - (%v) %v", err.Error(), resp.StatusCode, content)
 	}
-	if err := c.WriteMessage(websocket.BinaryMessage, []byte("ping")); err != nil {
+	if err := c.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
 		t.Errorf(err.Error())
 	}
 	mtype, p, err := c.ReadMessage()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if mtype != websocket.BinaryMessage {
+	if mtype != websocket.TextMessage {
 		t.Errorf("Unexpected message type %v", mtype)
 	}
 	if string(p) != "ping" {

--- a/subscriptions/ws_subscription_test.go
+++ b/subscriptions/ws_subscription_test.go
@@ -71,7 +71,7 @@ func TestWebsocketSubscriptionConsumer(t *testing.T) {
 		t.Fatalf("%v - (%v) %v", err.Error(), statusCode, content)
 	}
 
-	c.WriteMessage(websocket.BinaryMessage, []byte(`{
+	c.WriteMessage(websocket.TextMessage, []byte(`{
 	    "type": "subscribe",
 	    "channel": "orders",
 	    "requestId": "123e4567-e89b-12d3-a456-426655440000"
@@ -88,7 +88,7 @@ func TestWebsocketSubscriptionConsumer(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if mtype != websocket.BinaryMessage {
+	if mtype != websocket.TextMessage {
 		t.Errorf("Unexpected message type %v", mtype)
 	}
 


### PR DESCRIPTION
0x connect expects messages to be text type instead of binary type.
This may cause problems later if we want to use websocket channels
to send orders around, but for now it will get 0x connect users up
and running.