### PR TITLE
Increase order buffer size

### DIFF
--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -87,7 +87,7 @@ func Handler(publisher channels.Publisher, accounts accountsModule.AccountServic
 				return
 			}
 		} else if contentType == "application/json" {
-			var data [1024]byte
+			var data [4096]byte
 			jsonLength, err := r.Body.Read(data[:])
 			if err != nil && err != io.EOF {
 				log.Printf(err.Error())


### PR DESCRIPTION
We're seeing a problem where sometimes orders are being truncated
when sent to OpenRelay. The truncation is happening below 1024, so I'm
not certain that this will resolve the problem, however since the multi-asset
proxy was introduced it's possible for valid orders to exceed 1024 bytes
(though we don't support the multi-asset proxy yet), so I'm going to go
ahead and bump this and see if it helps